### PR TITLE
Load .env automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Indiana cites and cross-links papers on **Dynamic Neural Field Theory** (Atasoy 
 git clone https://github.com/ariannamethod/Indiana-AM.git
 cd Indiana-AM
 cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PERPLEXITY_API_KEY …
+# `.env` will be loaded automatically on startup
 pip install -r requirements.txt
 python main.py
 ```

--- a/main.py
+++ b/main.py
@@ -7,8 +7,11 @@ from aiogram.utils.chat_action import ChatActionSender
 from openai import OpenAI
 from openai.assistants import Assistants
 
+from dotenv import load_dotenv
 from utils.memory import MemoryManager
 from utils.tools import split_message
+
+load_dotenv()
 
 # --- Config ---
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")


### PR DESCRIPTION
## Summary
- load environment variables from `.env` by default
- note auto loading in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686f3c09490083298d1d6757f594a1d4