### PR TITLE
Persist assistant IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ CREATOR_CHAT=your_creator_chat_id_here
 PINECONE_API_KEY=your-pinecone-key
 PINECONE_INDEX=your-pinecone-index-name
 PINECONE_ENV=your-pinecone-environment
+CORE_ASSISTANT_ID=
+MEMORY_ASSISTANT_ID=

--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ Indiana cites and cross-links papers on **Dynamic Neural Field Theory** (Atasoy 
 git clone https://github.com/ariannamethod/Indiana-AM.git
 cd Indiana-AM
 cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PERPLEXITY_API_KEY …
+# After first run, fill CORE_ASSISTANT_ID and MEMORY_ASSISTANT_ID in .env
 pip install -r requirements.txt
 python main.py
 ```
+
+The first run will create `assistants.json` with generated IDs. Copy them to
+`CORE_ASSISTANT_ID` and `MEMORY_ASSISTANT_ID` in your `.env` to reuse the same
+assistants across restarts.
 
 ## 7. License  
 MIT — because archaeology of consciousness should stay open.


### PR DESCRIPTION
## Summary
- store created assistant IDs in `assistants.json`
- load existing assistant IDs from env vars or file
- document how to reuse saved IDs
- add placeholders in `.env.example`

## Testing
- `python -m py_compile main.py utils/memory.py utils/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_686f3c2d40b8832983c3677715a7ad50