### PR TITLE
Add newline at EOF and configure flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -35,3 +35,4 @@ class MemoryManager:
             return ""
         # склеиваем последние 5 ответов как контекст
         return "\n".join(r[0] for r in rows)
+

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -8,3 +8,4 @@ def split_message(text: str, max_length: int = 4000):
     if text:
         parts.append(text)
     return parts
+


### PR DESCRIPTION
## Summary
- fix missing trailing newline in `utils/memory.py`
- fix missing trailing newline in `utils/tools.py`
- add `.flake8` config for EOF checking

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3c38bef4832981a5013e22c62b58