### PR TITLE
Switch reasoning core to Perplexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Indiana treats every dialogue as a **site excavation**:
 | **Memory** | `gpt-4o-mini` | Fast, cheap, long-range context store (`/lighthouse-memory`). |
 | **Reasoning core** | `llama-3.1-sonar-small-128k-chat` | High-speed exploratory reasoning; builds “A→B→C→… ⇒ ?” chains. |
 
-Contrast is deliberate: GPT’s broad semantic net + Sonar’s crisp retrieval create a *Möbius loop* of perspectives.  
+Contrast is deliberate: GPT’s broad semantic net + Sonar’s crisp retrieval create a *Möbius loop* of perspectives.
 The current implementation follows **assistants-v2** threads for memory and direct REST calls for Sonar.
+Reasoning requests are sent to Perplexity's API, while long-term memory is stored and queried via OpenAI Assistants.
 
 ## 3. Genesis pipeline  
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3.0.0
 openai>=1.6
 python-dotenv
+httpx


### PR DESCRIPTION
## Summary
- call Perplexity's Sonar model for reasoning
- keep memory on OpenAI assistants
- document dual-engine setup in README
- add httpx to requirements

## Testing
- `python -m py_compile main.py utils/*.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686f88e5ebdc83298eea5de6abe89481