### PR TITLE
Fix pinecone import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Indiana cites and cross-links papers on **Dynamic Neural Field Theory** (Atasoy 
 git clone https://github.com/ariannamethod/Indiana-AM.git
 cd Indiana-AM
 cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PERPLEXITY_API_KEY …
-# also set AGENT_GROUP_ID, GROUP_CHAT and CREATOR_CHAT
+# also set AGENT_GROUP_ID, GROUP_CHAT, CREATOR_CHAT and PINECONE_API_KEY
 # `.env` will be loaded automatically on startup
 # After the first run assistant IDs will be stored in `assistants.json`.
 # If the saved assistant is missing it will be recreated and the file updated.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram>=3.0.0
 openai>=1.6
 python-dotenv
 httpx
+pinecone


### PR DESCRIPTION
## Summary
- install the `pinecone` package
- point to `PINECONE_API_KEY` in quick start docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a78b17864832990aa67e15e45408c