### PR TITLE
Fix Pinecone embedding dimension mismatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ CREATOR_CHAT=your_creator_chat_id_here
 PINECONE_API_KEY=your-pinecone-key
 PINECONE_INDEX=your-pinecone-index-name
 PINECONE_ENV=your-pinecone-environment
+EMBED_MODEL=text-embedding-3-small

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Indiana cites and cross-links papers on **Dynamic Neural Field Theory** (Atasoy 
 git clone https://github.com/ariannamethod/Indiana-AM.git
 cd Indiana-AM
 cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PERPLEXITY_API_KEY …
-# also set AGENT_GROUP_ID, GROUP_CHAT, CREATOR_CHAT and PINECONE_API_KEY
+# also set AGENT_GROUP_ID, GROUP_CHAT, CREATOR_CHAT, PINECONE_API_KEY and EMBED_MODEL
 # `.env` will be loaded automatically on startup
 # After the first run assistant IDs will be stored in `assistants.json`.
 # If the saved assistant is missing it will be recreated and the file updated.

--- a/utils/vectorstore.py
+++ b/utils/vectorstore.py
@@ -5,6 +5,7 @@ from openai import AsyncOpenAI
 
 class VectorStore:
     def __init__(self):
+        self.embed_model = os.getenv("EMBED_MODEL", "text-embedding-3-small")
         self.client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
         # Initialize Pinecone client
@@ -17,7 +18,7 @@ class VectorStore:
     async def embed_text(self, text: str):
         """Generate embeddings for text using OpenAI."""
         response = await self.client.embeddings.create(
-            model="text-embedding-3-large",
+            model=self.embed_model,
             input=text
         )
         return response.data[0].embedding


### PR DESCRIPTION
## Summary
- make embedding model configurable via `EMBED_MODEL`
- default to `text-embedding-3-small` to match typical 1536-dim indexes
- document new variable in README and `.env.example`

## Testing
- `flake8` *(fails: various style errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a815e55208329b7326e344cba12de