### PR TITLE
Fix deprecation warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import json
 import asyncio
 import random
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from aiogram import Bot, Dispatcher, types, F
 from aiogram.utils.chat_action import ChatActionSender
@@ -237,7 +237,7 @@ async def delayed_followup(chat_id: int, user_id: str, original: str, private: b
         text = await assemble_final_reply(original, draft)
 
         # Save to journal
-        save_note({"time": datetime.utcnow().isoformat(), "user": user_id, "followup": text})
+        save_note({"time": datetime.now(timezone.utc).isoformat(), "user": user_id, "followup": text})
 
         # Send response in chunks
         for chunk in split_message(text):
@@ -260,7 +260,7 @@ async def afterthought(chat_id: int, user_id: str, original: str, private: bool)
         text = await assemble_final_reply(original, draft)
 
         # Save to journal
-        entry = {"time": datetime.utcnow().isoformat(), "user": user_id, "afterthought": text}
+        entry = {"time": datetime.now(timezone.utc).isoformat(), "user": user_id, "afterthought": text}
         save_note(entry)
 
         # Send response in chunks
@@ -301,7 +301,7 @@ async def handle_message(m: types.Message):
 
         # 3) Save to memory and notes
         await memory.save(user_id, text, reply)
-        save_note({"time": datetime.utcnow().isoformat(), "user": user_id, "query": text, "response": reply})
+        save_note({"time": datetime.now(timezone.utc).isoformat(), "user": user_id, "query": text, "response": reply})
 
         # 4) Send response
         for chunk in split_message(reply):

--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -1,6 +1,6 @@
 import random
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 
 from openai import AsyncOpenAI
 
@@ -55,7 +55,7 @@ async def genesis2_filter(user_prompt: str, draft_reply: str) -> str:
         twist = await _call_openai(_build_prompt(draft_reply, user_prompt))
         return twist
     except Exception as e:
-        print(f"[Genesis-2] GPT fail {e}  @ {datetime.utcnow().isoformat()}")
+        print(f"[Genesis-2] GPT fail {e}  @ {datetime.now(timezone.utc).isoformat()}")
         return ""
 
 

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from .vectorstore import BaseVectorStore, create_vector_store
@@ -23,7 +23,7 @@ class MemoryManager:
 
     async def save(self, user_id: str, query: str, response: str):
         """Save user query and response to memory database."""
-        ts = datetime.utcnow().isoformat()
+        ts = datetime.now(timezone.utc).isoformat()
         self.db.execute(
             "INSERT INTO memory VALUES (?,?,?,?)",
             (user_id, ts, query, response)


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(timezone.utc)` everywhere

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaf8d50f08329b8152ca0b0dbf377