### PR TITLE
Switch genesis2 to GPT-o3 engine

### DIFF
--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -6,7 +6,7 @@ from openai import AsyncOpenAI
 
 from .config import settings
 
-OPENAI_MODEL = "gpt-4o"
+OPENAI_MODEL = "gpt-o3"
 TIMEOUT = 25
 
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None


### PR DESCRIPTION
## Summary
- update `OPENAI_MODEL` constant in `utils/genesis2.py` to use `gpt-o3`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ac4901b008329bf491b0f920e69e5