### PR TITLE
Fix Genesis2 model constant

### DIFF
--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -6,7 +6,11 @@ from openai import AsyncOpenAI
 
 from .config import settings
 
-OPENAI_MODEL = "gpt-o3"
+# Genesis2 previously referenced a non-existent model name.  The
+# correct OpenAI model identifier is simply "o3" as per the public
+# documentation.  Using the wrong name resulted in model_not_found
+# errors during runtime.
+OPENAI_MODEL = "o3"
 TIMEOUT = 25
 
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None


### PR DESCRIPTION
## Summary
- use correct model name `o3` for Genesis2 intuition filter

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ac835d34883298e11d41af8961b0f