### PR TITLE
Fix genesis2 parameter for new OpenAI API

### DIFF
--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -44,7 +44,7 @@ async def _call_openai(messages: list[dict[str, str]]) -> str:
         model=OPENAI_MODEL,
         temperature=0.9,
         messages=messages,
-        max_tokens=120,
+        max_completion_tokens=120,
         timeout=TIMEOUT,
     )
     return resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- update OpenAI call in `genesis2.py` to use `max_completion_tokens`

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_687acb7999408329868fec39b48d8ab4