### PR TITLE
Extend afterthought logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -251,8 +251,16 @@ async def afterthought(chat_id: int, user_id: str, original: str, private: bool)
         # Random delay between 1-2 hours
         await asyncio.sleep(random.uniform(3600, 7200))
 
-        prompt = f"#afterthought\nI've been thinking about: {original}"
+        # Retrieve the most recent answer to build on
+        prev_reply = await memory.last_response(user_id)
         context = await memory.retrieve(user_id, original)
+        prompt = (
+            "#afterthought\n"
+            "Extend your earlier answer. Review it carefully and add one more step "
+            "(A→B→C→D) leading to a paradoxical or deep conclusion. Connect with "
+            "any relevant memories.\n"
+            f"PREVIOUS >>> {prev_reply}\nUSER PROMPT >>> {original}"
+        )
 
         # Process with assistant instead of Sonar
         lang = get_user_language(user_id, original)

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -57,3 +57,12 @@ class MemoryManager:
             # log and fall back to empty list
             print(f"Vector search failed: {e}")
             return []
+
+    async def last_response(self, user_id: str) -> str:
+        """Return the most recent response for the given user."""
+        cur = self.db.execute(
+            "SELECT response FROM memory WHERE user_id=? ORDER BY timestamp DESC LIMIT 1",
+            (user_id,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else ""


### PR DESCRIPTION
## Summary
- add `last_response` helper to memory manager
- revise `afterthought` prompt to build on previous answer

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_687af40637c483298fd9c0fbf5a6b1aa