### PR TITLE
Fix user mixing in memory retrieval

### DIFF
--- a/main.py
+++ b/main.py
@@ -298,7 +298,7 @@ async def handle_message(m: types.Message):
 
         # 1) Load context from memory and artifacts
         mem_ctx = await memory.retrieve(user_id, text)
-        vector_ctx = "\n".join(await memory.search_memory(text))
+        vector_ctx = "\n".join(await memory.search_memory(user_id, text))
         system_ctx = ARTIFACTS_TEXT + "\n" + mem_ctx + "\n" + vector_ctx
         lang = get_user_language(user_id, text)
 

--- a/utils/dayandnight.py
+++ b/utils/dayandnight.py
@@ -20,8 +20,8 @@ async def _fetch_last_day():
 
 async def _store_last_day(date: str, text: str):
     try:
-        await vector_store.store(f"daily-{date}", text)
-        await vector_store.store("last-daily", text)
+        await vector_store.store(f"daily-{date}", text, user_id="daily")
+        await vector_store.store("last-daily", text, user_id="daily")
     except Exception:
         pass
 

--- a/utils/knowtheworld.py
+++ b/utils/knowtheworld.py
@@ -49,7 +49,7 @@ async def _store_insight(text: str):
     """Store generated insight in Pinecone with tag #knowtheworld."""
     try:
         now = datetime.now(timezone.utc).isoformat()
-        await vector_store.store(f"know-{now}", text)
+        await vector_store.store(f"know-{now}", text, user_id="world")
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- keep vector store entries scoped to each user
- allow searching vector memory by user ID
- ensure bot context only loads data from the requesting user
- update day/night and world tasks to store with special user IDs

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5b6262488329931b3e86506e1aaa