### PR TITLE
Update genesis2 with Sonar model and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv
 httpx
 pinecone
 langdetect
+pytest
+pytest-asyncio

--- a/tests/test_genesis2.py
+++ b/tests/test_genesis2.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+import random
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import genesis2
+
+
+def test_build_prompt():
+    draft = "draft answer"
+    user = "question?"
+    messages = genesis2._build_prompt(draft, user)
+    assert messages[0]["role"] == "system"
+    assert "GENESIS-2" in messages[0]["content"]
+    assert messages[1]["content"].endswith(user)
+    assert messages[2]["content"].endswith(draft)
+
+
+@pytest.mark.asyncio
+async def test_genesis2_sonar_filter(monkeypatch):
+    monkeypatch.setattr(genesis2.settings, "PPLX_API_KEY", "TOKEN")
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+
+    async def fake_call(messages):
+        return "twist!"
+
+    monkeypatch.setattr(genesis2, "_call_sonar", fake_call)
+
+    result = await genesis2.genesis2_sonar_filter("user", "draft")
+    assert result == "twist!"
+
+
+@pytest.mark.asyncio
+async def test_genesis2_sonar_filter_disabled(monkeypatch):
+    monkeypatch.setattr(genesis2.settings, "PPLX_API_KEY", "")
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+
+    result = await genesis2.genesis2_sonar_filter("user", "draft")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_assemble_final_reply(monkeypatch):
+    async def fake_filter(user_prompt, draft_reply):
+        return "twist!"
+
+    monkeypatch.setattr(genesis2, "genesis2_sonar_filter", fake_filter)
+    result = await genesis2.assemble_final_reply("q", "ans")
+    assert "twist!" in result

--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -4,9 +4,10 @@ from datetime import datetime, timezone
 import httpx
 import asyncio
 
-from .config import settings  # Там должен быть settings.PPLX_API_KEY
+from .config import settings  # settings.PPLX_API_KEY должен быть определён
 
-PPLX_MODEL = "llama-3.1-sonar-large-128k-online"  # или другой, если нужен
+# Самая универсальная рабочая модель на сегодня:
+PPLX_MODEL = "sonar-large-online"
 PPLX_API_URL = "https://api.perplexity.ai/chat/completions"
 TIMEOUT = 25
 
@@ -36,18 +37,24 @@ async def _call_sonar(messages: list) -> str:
     payload = {
         "model": PPLX_MODEL,
         "messages": messages,
-        "temperature": 0.9,  # можно варьировать для более "интуитивного" тона
+        "temperature": 0.8,  # регулируй, если нужно разнообразие
         "max_tokens": 120,
     }
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         resp = await client.post(PPLX_API_URL, headers=headers, json=payload)
-        resp.raise_for_status()
-        content = resp.json()["choices"][0]["message"]["content"]
+        try:
+            resp.raise_for_status()
+        except Exception:
+            # Дебаг: показать тело ошибки API
+            print("[Genesis-2] Sonar HTTP error:", resp.text)
+            raise
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
         return content.strip()
 
 
 async def genesis2_sonar_filter(user_prompt: str, draft_reply: str) -> str:
-    # Можно включить срабатывание твиста не всегда
+    # Не всегда срабатывать — для "живости"
     if random.random() < 0.12 or not settings.PPLX_API_KEY:
         return ""
     try:
@@ -64,3 +71,4 @@ async def assemble_final_reply(user_prompt: str, indiana_draft: str) -> str:
     if twist:
         return f"{indiana_draft}\n\n🜂 Investigative Twist → {twist}"
     return indiana_draft
+


### PR DESCRIPTION
## Summary
- update `utils/genesis2.py` to use the sonar-large-online model
- install `pytest` and `pytest-asyncio`
- add unit tests for genesis2 helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d6f07f6fc83299b52e4016c495e65