### PR TITLE
Add magnifying glass emoji to Genesis3 responses

### DIFF
--- a/tests/test_genesis3.py
+++ b/tests/test_genesis3.py
@@ -38,4 +38,4 @@ async def test_genesis3_deep_dive(monkeypatch):
     monkeypatch.setenv("PPLX_API_KEY", "TOKEN")
     monkeypatch.setattr(genesis3, "httpx", type("x", (), {"AsyncClient": DummyClient}))
     result = await genesis3.genesis3_deep_dive("thought", "prompt")
-    assert result == "deep insight"
+    assert result == "🔍 deep insight"

--- a/utils/genesis3.py
+++ b/utils/genesis3.py
@@ -35,4 +35,5 @@ async def genesis3_deep_dive(chain_of_thought: str, prompt: str) -> str:
     async with httpx.AsyncClient(timeout=60) as cli:
         r = await cli.post(SONAR_PRO_URL, headers=PRO_HEADERS, json=payload)
         r.raise_for_status()
-        return r.json()["choices"][0]["message"]["content"].strip()
+        content = r.json()["choices"][0]["message"]["content"].strip()
+        return f"🔍 {content}"


### PR DESCRIPTION
## Summary
- Prefix Genesis3 deep-dive responses with a magnifying glass emoji
- Adjust unit test for Genesis3 to expect the emoji-tagged output

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3f4c95088329800a751083c53807