### PR TITLE
Ensure bot sets menu commands safely

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,12 +110,17 @@ def reload_artifacts() -> None:
 repo_watcher = RepoWatcher(paths=[Path('.')], on_change=reload_artifacts)
 
 async def setup_bot_commands() -> None:
-    """Configure bot commands for menu button."""
+    """Configure bot commands and ensure the menu button is visible."""
     commands = [
-        types.BotCommand(command="deep", description=" "),
-        types.BotCommand(command="deepoff", description=" "),
+        types.BotCommand(command="deep", description="Enable deep mode"),
+        types.BotCommand(command="deepoff", description="Disable deep mode"),
     ]
-    await bot.set_my_commands(commands)
+    try:
+        await bot.set_my_commands(commands)
+        # Explicitly enable the commands menu button
+        await bot.set_chat_menu_button(menu_button=types.MenuButtonCommands())
+    except Exception as e:
+        logger.warning(f"Failed to set bot commands: {e}")
 
 def save_note(entry: dict):
     """Save an entry to the journal file."""


### PR DESCRIPTION
## Summary
- configure Telegram commands with descriptions
- ensure the commands menu button appears
- prevent startup failures if setting commands fails

## Testing
- `flake8 && echo 'flake8 passed'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e4e4116e48329ad8acf6c02b2aee8