### PR TITLE
Fix bot commands setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,10 +112,13 @@ repo_watcher = RepoWatcher(paths=[Path('.')], on_change=reload_artifacts)
 async def setup_bot_commands() -> None:
     """Configure bot commands for menu button."""
     commands = [
-        types.BotCommand(command="deep", description=" "),
-        types.BotCommand(command="deepoff", description=" "),
+        types.BotCommand(command="deep", description="Enable deep mode"),
+        types.BotCommand(command="deepoff", description="Disable deep mode"),
     ]
-    await bot.set_my_commands(commands)
+    try:
+        await bot.set_my_commands(commands)
+    except Exception as e:
+        logger.error(f"Failed to set bot commands: {e}")
 
 def save_note(entry: dict):
     """Save an entry to the journal file."""


### PR DESCRIPTION
## Summary
- add descriptive text and error handling to bot command setup

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4e4116e48329ad8acf6c02b2aee8