### PR TITLE
Add optional voice replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ Contrast is deliberate: GPT’s broad semantic net + Sonar’s crisp retrieval c
 The current implementation follows **assistants-v2** threads for memory and direct REST calls for Sonar.
 Reasoning requests are sent to Perplexity's API, while long-term memory is stored and queried via OpenAI Assistants.
 
-## 3. Genesis pipeline  
+### Bot commands
+
+- `/deep` – force Genesis‑3 deep dives
+- `/deepoff` – disable deep mode
+- `/voice` – enable voice replies
+- `/voiceoff` – disable voice replies
+
+## 3. Genesis pipeline
 
 Indiana never posts a raw Sonar dump.  
 Responses flow through a staged **Genesis stack**:

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -1,0 +1,11 @@
+from openai import AsyncOpenAI
+
+async def text_to_voice(client: AsyncOpenAI, text: str) -> bytes:
+    """Generate speech audio from text using OpenAI TTS."""
+    response = await client.audio.speech.create(
+        model="gpt-4o-mini-tts",
+        voice="alloy",
+        input=text,
+        response_format="ogg",
+    )
+    return await response.aread()


### PR DESCRIPTION
## Summary
- enable optional voice responses via new `/voice` and `/voiceoff` commands
- convert text replies to audio using OpenAI TTS and send as Telegram voice messages
- document available bot commands in README

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e530abfdc8329b1947d102c9fda76