### PR TITLE
Refine voice command labels and fix audio format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Reasoning requests are sent to Perplexity's API, while long-term memory is store
 
 ### Bot commands
 
-- `/deep` – force Genesis‑3 deep dives
-- `/deepoff` – disable deep mode
-- `/voice` – enable voice replies
-- `/voiceoff` – disable voice replies
+- `/deep` – deep mode
+- `/deepoff` – deep off
+- `/voiceon` – voice mode
+- `/voiceoff` – mute
 
 ## 3. Genesis pipeline
 

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ ASSISTANT_ID = None
 vector_store = create_vector_store()
 memory = MemoryManager(db_path="lighthouse_memory.db", vectorstore=vector_store)
 AFTERTHOUGHT_CHANCE = 0.1
-FOLLOWUP_CHANCE = 0.2
+FOLLOWUP_CHANCE = 0.1
 DetectorFactory.seed = 0
 USER_LANGS: dict[str, str] = {}
 VOICE_USERS: set[str] = set()
@@ -132,7 +132,7 @@ async def setup_bot_commands() -> None:
     commands = [
         types.BotCommand(command="deep", description="deep mode"),
         types.BotCommand(command="deepoff", description="deep off"),
-        types.BotCommand(command="voice", description="voice mode"),
+        types.BotCommand(command="voiceon", description="voice mode"),
         types.BotCommand(command="voiceoff", description="mute"),
     ]
     try:
@@ -360,7 +360,7 @@ async def disable_deep_mode(m: types.Message):
     await m.answer("deep mode disabled")
 
 
-@dp.message(F.text == "/voice")
+@dp.message(F.text.in_({"/voiceon", "/voice"}))
 async def enable_voice(m: types.Message):
     """Enable voice responses for the user."""
     VOICE_USERS.add(str(m.from_user.id))

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -9,7 +9,7 @@ async def text_to_voice(client: AsyncOpenAI, text: str) -> bytes:
         model="gpt-4o-mini-tts",
         voice="alloy",
         input=text,
-        response_format="ogg",
+        response_format="opus",
     )
     return await response.aread()
 


### PR DESCRIPTION
## Summary
- adjust follow-up chance and voice command handlers
- update voice synthesis format to opus
- refresh README bot command descriptions

## Testing
- `flake8 main.py utils/voice.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e6b958028832991657fb002e4d13c