### PR TITLE
Refine follow-up logic and voice replies

### DIFF
--- a/tests/test_genesis2.py
+++ b/tests/test_genesis2.py
@@ -11,7 +11,7 @@ from utils import genesis2  # noqa: E402
 def test_build_prompt():
     draft = "draft answer"
     user = "question?"
-    messages = genesis2._build_prompt(draft, user)
+    messages = genesis2._build_prompt(draft, user, "en")
     assert messages[0]["role"] == "system"
     assert "GENESIS-2" in messages[0]["content"]
     assert messages[1]["content"].endswith(user)
@@ -28,7 +28,7 @@ async def test_genesis2_sonar_filter(monkeypatch):
 
     monkeypatch.setattr(genesis2, "_call_sonar", fake_call)
 
-    result = await genesis2.genesis2_sonar_filter("user", "draft")
+    result = await genesis2.genesis2_sonar_filter("user", "draft", "en")
     assert result == "twist!"
 
 
@@ -37,15 +37,15 @@ async def test_genesis2_sonar_filter_disabled(monkeypatch):
     monkeypatch.setattr(genesis2.settings, "PPLX_API_KEY", "")
     monkeypatch.setattr(random, "random", lambda: 0.5)
 
-    result = await genesis2.genesis2_sonar_filter("user", "draft")
+    result = await genesis2.genesis2_sonar_filter("user", "draft", "en")
     assert result == ""
 
 
 @pytest.mark.asyncio
 async def test_assemble_final_reply(monkeypatch):
-    async def fake_filter(user_prompt, draft_reply):
+    async def fake_filter(user_prompt, draft_reply, language):
         return "twist!"
 
     monkeypatch.setattr(genesis2, "genesis2_sonar_filter", fake_filter)
-    result = await genesis2.assemble_final_reply("q", "ans")
+    result = await genesis2.assemble_final_reply("q", "ans", "en")
     assert "twist!" in result

--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -2,7 +2,6 @@ import random
 import textwrap
 from datetime import datetime, timezone
 import httpx
-import asyncio
 
 from .config import settings  # settings.PPLX_API_KEY должен быть определён
 
@@ -17,12 +16,13 @@ headers = {
 }
 
 
-def _build_prompt(draft: str, user_prompt: str) -> list:
+def _build_prompt(draft: str, user_prompt: str, language: str) -> list:
     system_msg = textwrap.dedent(
-        """
+        f"""
         You are GENESIS-2, the intuition filter for Indiana‐AM (“Indiana Jones” archetype).
         Return ONE short investigative twist (≤120 tokens) that deepens the current reasoning.
         Do **NOT** repeat the draft; just add an angle, question or hidden variable.
+        Reply in {language}.
         """
     ).strip()
     return [
@@ -53,12 +53,12 @@ async def _call_sonar(messages: list) -> str:
         return content.strip()
 
 
-async def genesis2_sonar_filter(user_prompt: str, draft_reply: str) -> str:
+async def genesis2_sonar_filter(user_prompt: str, draft_reply: str, language: str) -> str:
     # Не всегда срабатывать — для "живости"
     if random.random() < 0.12 or not settings.PPLX_API_KEY:
         return ""
     try:
-        messages = _build_prompt(draft_reply, user_prompt)
+        messages = _build_prompt(draft_reply, user_prompt, language)
         twist = await _call_sonar(messages)
         return twist
     except Exception as e:
@@ -66,8 +66,8 @@ async def genesis2_sonar_filter(user_prompt: str, draft_reply: str) -> str:
         return ""
 
 
-async def assemble_final_reply(user_prompt: str, indiana_draft: str) -> str:
-    twist = await genesis2_sonar_filter(user_prompt, indiana_draft)
+async def assemble_final_reply(user_prompt: str, indiana_draft: str, language: str) -> str:
+    twist = await genesis2_sonar_filter(user_prompt, indiana_draft, language)
     if twist:
         return f"{indiana_draft}\n\n🜂 Investigative Twist → {twist}"
     return indiana_draft


### PR DESCRIPTION
## Summary
- lower probability of automatic follow-ups and afterthoughts
- add Genesis-3 processing and memory summarization for follow-ups and afterthoughts
- ensure voice replies include audio plus text and streamline Sonar twist language handling

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e7cae20448329bb99600feb28c93e