### PR TITLE
fix: allow longer genesis3 responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,7 +296,7 @@ async def delayed_followup(chat_id: int, user_id: str, prev_reply: str, original
         draft = await process_with_assistant(prompt, context, lang)
         deep = ""
         try:
-            deep = await genesis3_deep_dive(draft, prev_reply)
+            deep = await genesis3_deep_dive(draft, original)
         except Exception as e:
             logger.error(f"[Genesis-3] followup fail {e}")
         quote = prev_reply if len(prev_reply) <= 500 else prev_reply[:497] + "..."

--- a/utils/genesis3.py
+++ b/utils/genesis3.py
@@ -3,6 +3,7 @@ import os
 
 SONAR_PRO_URL = "https://api.perplexity.ai/chat/completions"
 GEN3_MODEL = "sonar-reasoning-pro"
+GEN3_MAX_TOKENS = int(os.getenv("GEN3_MAX_TOKENS", "1024"))
 
 
 def _headers() -> dict:
@@ -28,7 +29,7 @@ async def genesis3_deep_dive(chain_of_thought: str, prompt: str) -> str:
     payload = {
         "model": GEN3_MODEL,
         "temperature": 0.65,
-        "max_tokens": 320,
+        "max_tokens": GEN3_MAX_TOKENS,
         "messages": [
             {"role": "system", "content": SYSTEM_PROMPT},
             {


### PR DESCRIPTION
## Summary
- allow configurable token limit for genesis3 deep dives
- analyze user original prompt in follow-up deep dives instead of bot reply

## Testing
- `flake8 && echo "flake8 ok"`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ecf0c359883298a559bf3c47e9686