### PR TITLE
Refactor message pipeline and unify message splitting

### DIFF
--- a/tests/test_genesis3.py
+++ b/tests/test_genesis3.py
@@ -46,7 +46,7 @@ async def test_genesis3_deep_dive(monkeypatch):
     monkeypatch.setenv("PPLX_API_KEY", "TOKEN")
     monkeypatch.setattr(genesis3, "httpx", type("x", (), {"AsyncClient": DummyClient}))
     result = await genesis3.genesis3_deep_dive("thought", "prompt")
-    assert result == "🔍 deep insight"
+    assert result == "🔍 deep insight..."
     assert "FOLLOWUP" not in captured[0]["messages"][1]["content"]
 
     await genesis3.genesis3_deep_dive("thought", "prompt", is_followup=True)


### PR DESCRIPTION
## Summary
- ensure Genesis-2 checks for truncated twists and remove duplicated split logic
- route followups and afterthoughts through Genesis-2 and Genesis-3 once before sending via unified splitter
- adjust tests for new ellipsis behaviour

## Testing
- `flake8 main.py utils/genesis2.py tests/test_genesis3.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891036de1d48329a77a6911387334f1