### PR TITLE
Use aiosqlite for async memory storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pinecone
 langdetect
 pytest
 pytest-asyncio
+aiosqlite


### PR DESCRIPTION
## Summary
- switch MemoryManager to aiosqlite for non-blocking DB access
- await async DB operations and vector store lookups
- add aiosqlite to requirements

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891807dd9a883298d93a2def980758d