### PR TITLE
Stop repo watcher on shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -547,8 +547,11 @@ async def on_startup(app):
 
 async def on_shutdown(app):
     """Cleanup on shutdown."""
-    # Nothing to clean up for now
-    pass
+    try:
+        repo_watcher.stop()
+        logger.info("Repo watcher stopped")
+    except Exception as e:
+        logger.error(f"Error stopping repo watcher: {e}")
 
 # --- Main function with webhook support ---
 async def main():


### PR DESCRIPTION
## Summary
- Stop repository watcher during application shutdown
- Log watcher termination and handle potential errors

## Testing
- `flake8` *(fails: W292, trailing whitespace, bare except in unrelated files)*
- `flake8 main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689180aa47e08329aba272cb5ae19c65