### PR TITLE
style: reorder genesis2 imports

### DIFF
--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -1,7 +1,7 @@
+import httpx
 import random
 import textwrap
 from datetime import datetime, timezone
-import httpx
 import re
 
 from .config import settings  # settings.PPLX_API_KEY должен быть определён


### PR DESCRIPTION
## Summary
- reorder genesis2 imports to ensure httpx, random, textwrap, and datetime are loaded at top

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891835d3df483298b52a86adf64b721