### PR TITLE
fix: import os for vector store

### DIFF
--- a/utils/vectorstore.py
+++ b/utils/vectorstore.py
@@ -1,10 +1,11 @@
-import os
 import asyncio
 import logging
+import os
+from difflib import SequenceMatcher
 from typing import Dict, List, Tuple
+
 from openai import AsyncOpenAI
 from pinecone import Pinecone
-from difflib import SequenceMatcher
 
 from .config import settings
 


### PR DESCRIPTION
## Summary
- reorder imports and ensure os is imported for vector store

## Testing
- `flake8` *(fails: W292, W291, E722, W292)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68918391fc8083298d93ca1ff483c43c