### PR TITLE
Ensure sys is imported before path modification in complexity test

### DIFF
--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,5 +1,5 @@
-import sys
 from pathlib import Path
+import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
## Summary
- Reorder imports in `tests/test_complexity.py` so `sys` is imported before appending to `sys.path`

## Testing
- `flake8 tests/test_complexity.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689183af403483298d7de6e62461ffb0