### PR TITLE
test: ensure imports before usage in genesis2 tests

### DIFF
--- a/tests/test_genesis2.py
+++ b/tests/test_genesis2.py
@@ -1,6 +1,7 @@
+import random
 import sys
 from pathlib import Path
-import random
+
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_genesis2.py` so `random`, `sys`, and `Path` are loaded before use

## Testing
- `pytest -q`
- `flake8 tests/test_genesis2.py`


------
https://chatgpt.com/codex/tasks/task_e_689183b1ba9c8329925d8fa1078d1831