### PR TITLE
Reorder imports in genesis3 tests

### DIFF
--- a/tests/test_genesis3.py
+++ b/tests/test_genesis3.py
@@ -1,6 +1,6 @@
+import pytest
 import sys
 from pathlib import Path
-import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
## Summary
- Reorder imports in `tests/test_genesis3.py` so `pytest`, `sys`, and `Path` are declared before modifying `sys.path`

## Testing
- `flake8 tests/test_genesis3.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689183b2adc88329a713f2962a6ca06f