### PR TITLE
Reset captured list before genesis3 deep dive test

### DIFF
--- a/tests/test_genesis3.py
+++ b/tests/test_genesis3.py
@@ -43,6 +43,7 @@ class DummyClient:
 
 @pytest.mark.asyncio
 async def test_genesis3_deep_dive(monkeypatch):
+    captured.clear()
     monkeypatch.setenv("PPLX_API_KEY", "TOKEN")
     monkeypatch.setattr(genesis3, "httpx", type("x", (), {"AsyncClient": DummyClient}))
     result = await genesis3.genesis3_deep_dive("thought", "prompt")


### PR DESCRIPTION
## Summary
- clear the global `captured` list at the start of `test_genesis3_deep_dive` to ensure a clean state for each run

## Testing
- `flake8 tests/test_genesis3.py --count`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891882fbdb4832995160374b3783817