### PR TITLE
Offload vector store writes to background task

### DIFF
--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiosqlite
 from datetime import datetime, timezone
 from typing import Optional
@@ -33,14 +34,17 @@ class MemoryManager:
             )
             await db.commit()
         if self.vectorstore:
-            try:
-                await self.vectorstore.store(
-                    f"{user_id}-{ts}",
-                    f"Q: {query}\nA: {response}",
-                    user_id=user_id,
-                )
-            except Exception:
-                pass
+            async def _store_vector():
+                try:
+                    await self.vectorstore.store(
+                        f"{user_id}-{ts}",
+                        f"Q: {query}\nA: {response}",
+                        user_id=user_id,
+                    )
+                except Exception:
+                    pass
+
+            asyncio.create_task(_store_vector())
 
     async def retrieve(self, user_id: str, query: str) -> str:
         """Retrieve last 5 responses for a given user as context."""


### PR DESCRIPTION
## Summary
- offload vector store storage to a background task so save stays non-blocking
- maintain async sqlite access with aiosqlite in memory manager

## Testing
- `flake8 utils/memory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c3e5d6748329a8821971f984313e