### PR TITLE
Use async DB access in knowtheworld context fetch

### DIFF
--- a/utils/knowtheworld.py
+++ b/utils/knowtheworld.py
@@ -37,11 +37,7 @@ async def _location() -> str:
 
 async def _fetch_recent_messages(limit: int = 10) -> str:
     """Return last `limit` messages from memory as context."""
-    cur = memory.db.execute(
-        "SELECT query, response FROM memory ORDER BY timestamp DESC LIMIT ?",
-        (limit,),
-    )
-    rows = cur.fetchall()
+    rows = await memory.recent_messages(limit)
     if not rows:
         return ""
     return "\n".join(f"Q: {q}\nA: {a}" for q, a in rows)

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -60,6 +60,17 @@ class MemoryManager:
         # склеиваем последние 5 ответов как контекст
         return "\n".join(r[0] for r in rows)
 
+    async def recent_messages(self, limit: int = 10) -> list[tuple[str, str]]:
+        """Return recent query/response pairs across all users."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await self._init_db(db)
+            async with db.execute(
+                "SELECT query, response FROM memory ORDER BY timestamp DESC LIMIT ?",
+                (limit,),
+            ) as cur:
+                rows = await cur.fetchall()
+        return rows
+
     async def search_memory(self, user_id: str, query: str, top_k: int = 5) -> list[str]:
         """Search vector memory for similar texts belonging to the given user."""
         if not self.vectorstore:


### PR DESCRIPTION
## Summary
- expose recent query/response retrieval in `MemoryManager`
- reuse new helper in `knowtheworld` to avoid direct DB access

## Testing
- `python -m ruff check utils/memory.py utils/knowtheworld.py`
- `python -m pytest tests`
- `python -m pytest PITOMADOM/tests` *(fails: ModuleNotFoundError: scripts, server)*

------
https://chatgpt.com/codex/tasks/task_e_689416cb5a308329a3a82da0e0b1d187