### PR TITLE
Handle optional deps in context processor

### DIFF
--- a/tests/test_context_neural_processor.py
+++ b/tests/test_context_neural_processor.py
@@ -1,0 +1,17 @@
+import asyncio
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.context_neural_processor import parse_and_store_file
+
+
+@pytest.mark.asyncio
+async def test_parse_and_store_text(tmp_path):
+    file = tmp_path / "example.txt"
+    file.write_text("Hello Indiana")
+    result = await parse_and_store_file(str(file))
+    assert "Tags:" in result
+    assert "Summary:" in result

--- a/utils/vectorstore.py
+++ b/utils/vectorstore.py
@@ -1,11 +1,14 @@
-import os
 import asyncio
 import logging
 from difflib import SequenceMatcher
 from typing import Dict, List, Tuple
+import os
 
 from openai import AsyncOpenAI
-from pinecone import Pinecone
+try:  # Optional dependency
+    from pinecone import Pinecone
+except ImportError:  # pragma: no cover - optional
+    Pinecone = None
 
 from .config import settings
 
@@ -23,58 +26,61 @@ class BaseVectorStore:
         raise NotImplementedError
 
 
-class RemoteVectorStore(BaseVectorStore):
-    def __init__(self):
-        self.embed_model = os.getenv("EMBED_MODEL", "text-embedding-3-small")
-        self.client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
-        self.pc = Pinecone(api_key=settings.PINECONE_API_KEY)
-        self.index_name = settings.PINECONE_INDEX
-        self.index = self.pc.Index(self.index_name)
+if Pinecone:
+    class RemoteVectorStore(BaseVectorStore):
+        def __init__(self):
+            self.embed_model = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+            self.client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+            self.pc = Pinecone(api_key=settings.PINECONE_API_KEY)
+            self.index_name = settings.PINECONE_INDEX
+            self.index = self.pc.Index(self.index_name)
 
-    async def embed_text(self, text: str) -> List[float]:
-        for attempt in range(3):
-            try:
-                response = await self.client.embeddings.create(
-                    model=self.embed_model,
-                    input=text,
-                )
-                return response.data[0].embedding
-            except Exception as e:
-                logger.error("Embed attempt %s failed: %s", attempt + 1, e)
-                if attempt == 2:
-                    raise
-                await asyncio.sleep(2 ** attempt)
+        async def embed_text(self, text: str) -> List[float]:
+            for attempt in range(3):
+                try:
+                    response = await self.client.embeddings.create(
+                        model=self.embed_model,
+                        input=text,
+                    )
+                    return response.data[0].embedding
+                except Exception as e:
+                    logger.error("Embed attempt %s failed: %s", attempt + 1, e)
+                    if attempt == 2:
+                        raise
+                    await asyncio.sleep(2 ** attempt)
 
-    async def store(self, id: str, text: str, *, user_id: str | None = None):
-        vector = await self.embed_text(text)
-        for attempt in range(3):
-            try:
-                metadata = {"text": text}
-                if user_id:
-                    metadata["user"] = user_id
-                self.index.upsert(vectors=[(id, vector, metadata)])
-                return
-            except Exception as e:
-                logger.error("Pinecone upsert attempt %s failed: %s", attempt + 1, e)
-                if attempt == 2:
+        async def store(self, id: str, text: str, *, user_id: str | None = None):
+            vector = await self.embed_text(text)
+            for attempt in range(3):
+                try:
+                    metadata = {"text": text}
+                    if user_id:
+                        metadata["user"] = user_id
+                    self.index.upsert(vectors=[(id, vector, metadata)])
                     return
-                await asyncio.sleep(2 ** attempt)
+                except Exception as e:
+                    logger.error("Pinecone upsert attempt %s failed: %s", attempt + 1, e)
+                    if attempt == 2:
+                        return
+                    await asyncio.sleep(2 ** attempt)
 
-    async def search(self, query: str, top_k: int = 5, *, user_id: str | None = None) -> List[str]:
-        query_vector = await self.embed_text(query)
-        for attempt in range(3):
-            try:
-                params = dict(vector=query_vector, top_k=top_k, include_metadata=True)
-                if user_id:
-                    params["filter"] = {"user": {"$eq": user_id}}
-                results = self.index.query(**params)
-                return [m["metadata"]["text"] for m in results["matches"]]
-            except Exception as e:
-                logger.error("Pinecone query attempt %s failed: %s", attempt + 1, e)
-                if attempt == 2:
-                    return []
-                await asyncio.sleep(2 ** attempt)
-        return []
+        async def search(self, query: str, top_k: int = 5, *, user_id: str | None = None) -> List[str]:
+            query_vector = await self.embed_text(query)
+            for attempt in range(3):
+                try:
+                    params = dict(vector=query_vector, top_k=top_k, include_metadata=True)
+                    if user_id:
+                        params["filter"] = {"user": {"$eq": user_id}}
+                    results = self.index.query(**params)
+                    return [m["metadata"]["text"] for m in results["matches"]]
+                except Exception as e:
+                    logger.error("Pinecone query attempt %s failed: %s", attempt + 1, e)
+                    if attempt == 2:
+                        return []
+                    await asyncio.sleep(2 ** attempt)
+            return []
+else:  # pragma: no cover - optional
+    RemoteVectorStore = None
 
 
 class LocalVectorStore(BaseVectorStore):
@@ -97,10 +103,15 @@ class LocalVectorStore(BaseVectorStore):
 
 
 def create_vector_store() -> BaseVectorStore:
-    if settings.OPENAI_API_KEY and settings.PINECONE_API_KEY:
+    if (
+        Pinecone
+        and settings.OPENAI_API_KEY
+        and settings.PINECONE_API_KEY
+        and RemoteVectorStore is not None
+    ):
         try:
             return RemoteVectorStore()
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - network
             logger.error("Failed to initialise remote vector store: %s", e)
     logger.warning("Using local vector store fallback")
     return LocalVectorStore()


### PR DESCRIPTION
## Summary
- guard HTML and PDF parsing against missing BeautifulSoup and PyPDF
- fall back to local vector store when Pinecone is absent
- add test for parse_and_store_file

## Testing
- `python -m py_compile utils/context_neural_processor.py utils/vectorstore.py tests/test_context_neural_processor.py`
- `pytest tests/test_context_neural_processor.py tests/test_complexity.py tests/test_genesis2.py tests/test_genesis3.py tests/test_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c5e9fca88329b187343d1c36c10a