### PR TITLE
Remove dynamic weights from context processor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numpy
 pypdf
 python-docx
 striprtf
-textract
+textract==1.6.3
 odfpy
 pillow
 pandas


### PR DESCRIPTION
## Summary
- Drop dependency on `dynamic_weights` in context processor by introducing a local `apply_pulse` helper
- Simplify `ChaosPulse` and `paraphrase` to operate without dynamic knowledge queries
- Streamline `parse_and_store_file` to extract content directly
- Pin `textract` to 1.6.3 to resolve invalid dependency metadata during builds

## Testing
- `flake8 utils/context_neural_processor.py`
- `pytest tests/test_context_neural_processor.py::test_parse_and_store_text -q`


------
https://chatgpt.com/codex/tasks/task_e_6898cb03fd2883299eaf853e36526d3a