### PR TITLE
Fix missing six dependency for langdetect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv
 httpx
 pinecone
 langdetect
+six==1.12.0
 pytest
 pytest-asyncio
 aiosqlite


### PR DESCRIPTION
## Summary
- add explicit six dependency so langdetect works in production

## Testing
- `flake8 .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_6898d0de338c832990670a27685f5927