### PR TITLE
Fix langdetect crash by updating six dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,11 @@ python-dotenv
 httpx
 pinecone
 langdetect
-six==1.12.0
+# Six 1.12.0 relies on the deprecated find_module API, which was removed in
+# Python 3.12. This caused `from six.moves import ...` imports to fail,
+# crashing the application when langdetect attempted to import six. Updating to
+# a newer release restores compatibility with Python 3.12.
+six>=1.16.0
 pytest
 pytest-asyncio
 aiosqlite
@@ -14,7 +18,6 @@ numpy
 pypdf
 python-docx
 striprtf
-textract==1.6.3
 odfpy
 pillow
 pandas


### PR DESCRIPTION
## Summary
- upgrade six to >=1.16.0 for Python 3.12 compatibility
- drop optional textract dependency to avoid six version conflicts

## Testing
- `python -m main`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts'; No module named 'server'; import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6898d63939688329b3b60db9aeec7ce9