### PR TITLE
fix: upgrade six for langdetect compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ python-dotenv
 httpx
 pinecone
 langdetect
-six==1.12.0
+# Use a modern six version; older release 1.12.0 lacks six.moves on Python 3.12
+six>=1.16.0
 pytest
 pytest-asyncio
 aiosqlite


### PR DESCRIPTION
## Summary
- bump six to >=1.16.0 to restore six.moves on Python 3.12

## Testing
- `pytest -q` *(fails: No module named 'scripts'; No module named 'server')*

------
https://chatgpt.com/codex/tasks/task_e_6898d63939688329b3b60db9aeec7ce9