### PR TITLE
fix langdetect crash on Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv
 httpx
 pinecone
 langdetect
-six==1.12.0
+six>=1.16.0
 pytest
 pytest-asyncio
 aiosqlite
@@ -14,7 +14,6 @@ numpy
 pypdf
 python-docx
 striprtf
-textract==1.6.3
 odfpy
 pillow
 pandas


### PR DESCRIPTION
## Summary
- update six dependency to 1.16+ and drop textract to avoid conflicts

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d63939688329b3b60db9aeec7ce9