### PR TITLE
Fix document download with bot API

### DIFF
--- a/main.py
+++ b/main.py
@@ -548,7 +548,7 @@ async def handle_document(m: types.Message):
         async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
             ARTIFACTS_DIR.mkdir(exist_ok=True)
             file_path = ARTIFACTS_DIR / m.document.file_name
-            await m.document.download(destination=str(file_path))
+            await bot.download(m.document, destination=str(file_path))
             processed = await parse_and_store_file(str(file_path))
             match = re.search(r"Summary: (.*)\nRelevance:", processed, re.DOTALL)
             summary = match.group(1).strip() if match else processed[:200]


### PR DESCRIPTION
## Summary
- replace deprecated `m.document.download` with `bot.download` to handle incoming documents

## Testing
- `flake8 main.py`
- `flake8 .` *(fails: E301 expected 1 blank line, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*


------
https://chatgpt.com/codex/tasks/task_e_6898e8fe553483299707eabb8fafd67e