### PR TITLE
Sanitize uploaded document filenames

### DIFF
--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.tools import sanitize_filename  # noqa: E402
+
+
+def test_sanitize_filename_removes_traversal():
+    assert sanitize_filename('../secret.txt') == 'secret.txt'


### PR DESCRIPTION
## Summary
- sanitize uploaded document names and strip suspicious characters
- reject overly large document uploads and use sanitized names for processing
- test that filenames containing `../` are cleaned

## Testing
- `flake8` *(fails: E301, E231, ... in unrelated files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts', etc.)*
- `pytest tests/test_filename.py`


------
https://chatgpt.com/codex/tasks/task_e_6899e27eca2c8329907871c4a8f82824