### PR TITLE
feat: add LRU cache for user languages with cleanup

### DIFF
--- a/utils/lru_cache.py
+++ b/utils/lru_cache.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+import time
+
+
+class LRUCache:
+    """Simple LRU cache with max length and TTL support."""
+
+    def __init__(self, maxlen: int = 1024):
+        self.maxlen = maxlen
+        self._data: OrderedDict[str, tuple[str, float]] = OrderedDict()
+
+    def get(self, key: str, default=None):
+        item = self._data.get(key)
+        if item is None:
+            return default
+        value, _ = item
+        self._data.move_to_end(key)
+        self._data[key] = (value, time.time())
+        return value
+
+    def set(self, key: str, value: str):
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = (value, time.time())
+        if len(self._data) > self.maxlen:
+            self._data.popitem(last=False)
+
+    def cleanup(self, max_age: float) -> None:
+        cutoff = time.time() - max_age
+        keys = [k for k, (_, ts) in self._data.items() if ts < cutoff]
+        for k in keys:
+            del self._data[k]


### PR DESCRIPTION
## Summary
- replace global user language mapping with bounded LRU cache
- periodically purge stale language entries
- add simple LRU cache utility

## Testing
- `flake8 main.py utils/lru_cache.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `pytest tests/test_complexity.py tests/test_context_neural_processor.py tests/test_filename.py tests/test_genesis3.py tests/test_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ed9bad888329b4cbaf5b4c643ce6