### PR TITLE
Add centralized task scheduler with task limits and cancellation

### DIFF
--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -1,0 +1,43 @@
+import asyncio as aio
+import pytest
+
+from utils.task_scheduler import TaskScheduler
+
+
+@pytest.mark.asyncio
+async def test_scheduler_limits_concurrency():
+    scheduler = TaskScheduler(max_active=1)
+    order = []
+
+    async def job(i):
+        await aio.sleep(0.05)
+        order.append(i)
+
+    scheduler.schedule(job(1))
+    scheduler.schedule(job(2))
+
+    await aio.sleep(0.06)
+    assert order == [1]
+    await aio.sleep(0.2)
+    await scheduler.shutdown()
+    assert order == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_cancel_user_tasks():
+    scheduler = TaskScheduler(max_active=1)
+    flag = {"ran": False}
+
+    async def job():
+        try:
+            await aio.sleep(0.5)
+            flag["ran"] = True
+        except aio.CancelledError:
+            raise
+
+    scheduler.schedule(job(), user_id="u1")
+    await aio.sleep(0.1)
+    scheduler.cancel_user_tasks("u1")
+    await aio.sleep(0.1)
+    await scheduler.shutdown()
+    assert not flag["ran"]

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from .vectorstore import BaseVectorStore, create_vector_store
+from .task_scheduler import scheduler
 
 class MemoryManager:
     def __init__(self, db_path: str = "memory.db", vectorstore: Optional[BaseVectorStore] = None):
@@ -60,7 +61,7 @@ class MemoryManager:
                 except Exception:
                     pass
 
-            asyncio.create_task(_store_vector())
+            scheduler.schedule(_store_vector(), user_id)
 
     async def retrieve(self, user_id: str, query: str) -> str:
         """Retrieve last 5 responses for a given user as context."""

--- a/utils/task_scheduler.py
+++ b/utils/task_scheduler.py
@@ -1,0 +1,64 @@
+import asyncio
+import logging
+from collections import defaultdict
+from contextlib import suppress
+from typing import Any, Awaitable
+
+
+class TaskScheduler:
+    """Simple centralized scheduler with a limit on active tasks."""
+
+    def __init__(self, max_active: int = 5):
+        self.max_active = max_active
+        self._queue: asyncio.Queue[tuple[Awaitable[Any], str | None]] = asyncio.Queue()
+        self._active: set[asyncio.Task] = set()
+        self._user_tasks: defaultdict[str, set[asyncio.Task]] = defaultdict(set)
+        self._logger = logging.getLogger(__name__)
+        loop = asyncio.get_event_loop()
+        self._runner = loop.create_task(self._run())
+
+    async def _run(self) -> None:
+        while True:
+            coro, user_id = await self._queue.get()
+            await self._start_task(coro, user_id)
+
+    async def _start_task(self, coro: Awaitable[Any], user_id: str | None) -> None:
+        while len(self._active) >= self.max_active:
+            await asyncio.sleep(0.1)
+        task = asyncio.create_task(coro)
+        self._active.add(task)
+        if user_id:
+            self._user_tasks[user_id].add(task)
+        task.add_done_callback(lambda t, u=user_id: self._finish_task(t, u))
+
+    def _finish_task(self, task: asyncio.Task, user_id: str | None) -> None:
+        self._active.discard(task)
+        if user_id:
+            self._user_tasks[user_id].discard(task)
+        self._logger.info("Waiting tasks: %d", self._queue.qsize())
+
+    def schedule(self, coro: Awaitable[Any], user_id: str | None = None) -> None:
+        """Schedule a coroutine for execution."""
+        self._queue.put_nowait((coro, user_id))
+        self._logger.info("Waiting tasks: %d", self._queue.qsize())
+
+    def cancel_user_tasks(self, user_id: str) -> None:
+        """Cancel all tasks belonging to a specific user."""
+        tasks = self._user_tasks.pop(user_id, set())
+        for task in tasks:
+            task.cancel()
+
+    async def shutdown(self) -> None:
+        """Cancel all running tasks and stop the scheduler."""
+        while not self._queue.empty():
+            await self._queue.get()
+        for task in list(self._active):
+            task.cancel()
+        with suppress(Exception):
+            await asyncio.gather(*self._active, return_exceptions=True)
+        self._runner.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._runner
+
+
+scheduler = TaskScheduler()


### PR DESCRIPTION
## Summary
- implement `TaskScheduler` to queue coroutines, cap concurrent tasks, cancel user jobs, and log waiting counts
- integrate scheduler with memory operations and bot workflow, including `/exit` command and clean shutdown
- add tests for scheduler behavior

## Testing
- `flake8 tests/test_task_scheduler.py utils/task_scheduler.py main.py utils/memory.py`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6899ed0e478c8329be63d537a750ebfe