### PR TITLE
Add memory rotation and private chat logging controls

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -14,5 +14,8 @@ class Settings:
     GROUP_CHAT: str = os.getenv("GROUP_CHAT", "")
     CREATOR_CHAT: str = os.getenv("CREATOR_CHAT", "")
     PPLX_API_KEY: str = os.getenv("PPLX_API_KEY", os.getenv("PERPLEXITY_API_KEY", ""))
+    LOG_PRIVATE_CHATS: bool = os.getenv("LOG_PRIVATE_CHATS", "true").lower() != "false"
+    ANONYMIZE_PRIVATE_DATA: bool = os.getenv("ANONYMIZE_PRIVATE_DATA", "false").lower() == "true"
+    MAX_MEMORY_RECORDS: int = int(os.getenv("MAX_MEMORY_RECORDS", "1000"))
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- add record limit enforcement to memory manager
- allow disabling or anonymizing private chat logs via settings
- integrate privacy-aware saving in bot handlers

## Testing
- `flake8` *(fails: INDIANA_CHAIN/indiana_core.py:165:5 E301 expected 1 blank line, found 0 ...)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'server')*

------
https://chatgpt.com/codex/tasks/task_e_6899edacfbbc8329af29a017c2497c61