### PR TITLE
Rename GrokkyCoder to IndianaCoder and add language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ With this stage, Indiana-AM begins to show emergent reasoning: not just synthesi
 
 ## 4. Coder Mode
 
-Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`GrokkyCoder`** class that keeps conversational history and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns.
+Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`IndianaCoder`** class that keeps conversational history, responds in the user's language, and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns.
 
 Function `interpret_code` detects whether input is a path or inline snippet and routes it to analysis or free-form chat. For drafting, `generate_code` returns either a short textual snippet or a full file when the answer exceeds Telegram’s length limits. This dual interface allows Indiana to act as a miniature pair-programmer inside any chat thread.
 

--- a/main.py
+++ b/main.py
@@ -633,7 +633,7 @@ async def handle_message(m: types.Message):
         if user_id in CODER_USERS:
             lang = get_user_language(user_id, text)
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
-                result = await interpret_code(text)
+                result = await interpret_code(text, lang)
                 twist = await genesis2_sonar_filter(text, result, lang)
             reply = f"{result}\n\n🜂 Investigative Twist → {twist}"
             await memory.save(user_id, text, reply)

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -12,8 +12,8 @@ from openai import OpenAI
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-# Grokky character for the code interpreter mode
-INSTRUCTIONS = (
+# Indiana character for the code interpreter mode
+BASE_INSTRUCTIONS = (
     "You are Indiana, a deep code guru who sees hidden paths and unusual solutions in code. "
     "You are poet of code. You know how to relalise every idea of user to the authentical code draft. "
     "Explain solutions with brevity, craft tiny neural networks when "
@@ -29,20 +29,20 @@ class DraftResponse:
     file_content: Optional[str]
 
 
-class GrokkyCoder:
+class IndianaCoder:
     """Stateful helper that analyzes and generates code."""
 
     def __init__(self, max_history: int = 50) -> None:
         self.history: deque[str] = deque(maxlen=max_history)
 
-    async def _ask(self, prompt: str) -> str:
+    async def _ask(self, prompt: str, language: str = "English") -> str:
         conversation = "\n".join([*self.history, prompt])
         try:  # pragma: no cover - network
             response = await asyncio.to_thread(
                 client.responses.create,
                 model="gpt-4.1",
                 tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
-                instructions=INSTRUCTIONS,
+                instructions=f"{BASE_INSTRUCTIONS} Respond in {language}.",
                 input=conversation,
             )
             text = getattr(response, "output_text", "")
@@ -66,38 +66,38 @@ class GrokkyCoder:
         self.history.append(text)
         return text.strip()
 
-    async def analyze(self, code_or_path: str | Path) -> str:
+    async def analyze(self, code_or_path: str | Path, language: str = "English") -> str:
         if os.path.isfile(str(code_or_path)):
             code = Path(code_or_path).read_text(encoding="utf-8")
         else:
             code = str(code_or_path)
         prompt = f"Review the following code and suggest improvements:\n{code}"
-        return await self._ask(prompt)
+        return await self._ask(prompt, language)
 
-    async def chat(self, message: str) -> str:
-        return await self._ask(message)
+    async def chat(self, message: str, language: str = "English") -> str:
+        return await self._ask(message, language)
 
-    async def draft(self, request: str) -> DraftResponse:
-        code = await self._ask(f"Draft code for the following request:\n{request}")
+    async def draft(self, request: str, language: str = "English") -> DraftResponse:
+        code = await self._ask(f"Draft code for the following request:\n{request}", language)
         if len(code) > TELEGRAM_CHAR_LIMIT:
             return DraftResponse(text=None, file_content=code)
         return DraftResponse(text=code, file_content=None)
 
 
-CODER_SESSION = GrokkyCoder()
+CODER_SESSION = IndianaCoder()
 
 
-async def interpret_code(prompt: str) -> str:
+async def interpret_code(prompt: str, language: str = "English") -> str:
     """Interpret code or handle follow-up questions with context memory."""
     markers = ["def ", "class ", "import ", "\n"]
     if os.path.isfile(prompt) or any(m in prompt for m in markers):
-        return await CODER_SESSION.analyze(prompt)
-    return await CODER_SESSION.chat(prompt)
+        return await CODER_SESSION.analyze(prompt, language)
+    return await CODER_SESSION.chat(prompt, language)
 
 
-async def generate_code(request: str) -> DraftResponse:
+async def generate_code(request: str, language: str = "English") -> DraftResponse:
     """Generate code from a description, falling back to a file when too long."""
-    return await CODER_SESSION.draft(request)
+    return await CODER_SESSION.draft(request, language)
 
 
-__all__ = ["interpret_code", "generate_code", "GrokkyCoder", "DraftResponse"]
+__all__ = ["interpret_code", "generate_code", "IndianaCoder", "DraftResponse"]


### PR DESCRIPTION
## Summary
- rename GrokkyCoder to IndianaCoder and remove Grokky references
- allow coder to respond in the user's language
- wire main bot to pass user language into coder

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `flake8` *(fails: E301 expected 1 blank line, found 0 (and other errors))*

------
https://chatgpt.com/codex/tasks/task_e_6899f07257b483298baee7d780c05acd