### PR TITLE
Rename coder persona and align language handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ With this stage, Indiana-AM begins to show emergent reasoning: not just synthesi
 
 ## 4. Coder Mode
 
-Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`GrokkyCoder`** class that keeps conversational history and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns.
+Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`IndianaCoder`** class that keeps conversational history and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns and answers in the user's language.
 
 Function `interpret_code` detects whether input is a path or inline snippet and routes it to analysis or free-form chat. For drafting, `generate_code` returns either a short textual snippet or a full file when the answer exceeds Telegram’s length limits. This dual interface allows Indiana to act as a miniature pair-programmer inside any chat thread.
 

--- a/main.py
+++ b/main.py
@@ -633,7 +633,7 @@ async def handle_message(m: types.Message):
         if user_id in CODER_USERS:
             lang = get_user_language(user_id, text)
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
-                result = await interpret_code(text)
+                result = await interpret_code(text, language=lang)
                 twist = await genesis2_sonar_filter(text, result, lang)
             reply = f"{result}\n\n🜂 Investigative Twist → {twist}"
             await memory.save(user_id, text, reply)


### PR DESCRIPTION
## Summary
- rename `GrokkyCoder` to `IndianaCoder` and remove Grokky references
- allow coder utilities to respond in the user's language
- update main to pass detected language and revise README docs

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError for missing 'scripts' and 'server' modules)*

------
https://chatgpt.com/codex/tasks/task_e_6899f07257b483298baee7d780c05acd