### PR TITLE
Rename GrokkyCoder to IndianaCoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ With this stage, Indiana-AM begins to show emergent reasoning: not just synthesi
 
 ## 4. Coder Mode
 
-Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`GrokkyCoder`** class that keeps conversational history and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns.
+Indiana includes a dedicated coder persona powered by `utils/coder.py`. The module exposes an asynchronous **`IndianaCoder`** class that keeps conversational history and communicates with OpenAI’s Responses API through the **code-interpreter** tool. Users can inspect files, request refactors, or maintain an evolving dialogue about algorithms, all while the system preserves context between turns.
 
 Function `interpret_code` detects whether input is a path or inline snippet and routes it to analysis or free-form chat. For drafting, `generate_code` returns either a short textual snippet or a full file when the answer exceeds Telegram’s length limits. This dual interface allows Indiana to act as a miniature pair-programmer inside any chat thread.
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -6,14 +6,14 @@ from pathlib import Path
 # Ensure project root is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from utils.coder import ACCESS_DENIED_MESSAGE, GrokkyCoder  # noqa: E402
+from utils.coder import ACCESS_DENIED_MESSAGE, IndianaCoder  # noqa: E402
 
 
 def test_analyze_denies_outside_repo(tmp_path):
     outside_file = tmp_path / "code.py"
     outside_file.write_text("print('hi')", encoding="utf-8")
 
-    coder = GrokkyCoder()
+    coder = IndianaCoder()
     result = asyncio.run(coder.analyze(str(outside_file)))
     assert result == ACCESS_DENIED_MESSAGE
 
@@ -23,12 +23,12 @@ def test_analyze_allows_repo_file(monkeypatch):
     inside_file = repo_root / "tmp_test_file.py"
     inside_file.write_text("print('hi')", encoding="utf-8")
 
-    coder = GrokkyCoder()
+    coder = IndianaCoder()
 
     async def fake_ask(self, prompt: str) -> str:  # pragma: no cover - simple stub
         return "OK"
 
-    monkeypatch.setattr(GrokkyCoder, "_ask", fake_ask)
+    monkeypatch.setattr(IndianaCoder, "_ask", fake_ask)
 
     try:
         result = asyncio.run(coder.analyze(str(inside_file)))

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Message returned when attempting to read outside of the repository
 ACCESS_DENIED_MESSAGE = "Access to files outside the repository is denied."
 
-# Grokky character for the code interpreter mode
+# Indiana character for the code interpreter mode
 INSTRUCTIONS = (
     "You are Indiana, a deep code guru who sees hidden paths and unusual solutions in code. "
     "You are poet of code. You know how to relalise every idea of user to the authentical code draft. "
@@ -36,7 +36,7 @@ class DraftResponse:
     file_content: Optional[str]
 
 
-class GrokkyCoder:
+class IndianaCoder:
     """Stateful helper that analyzes and generates code."""
 
     def __init__(self, max_history: int = 50) -> None:
@@ -97,7 +97,7 @@ class GrokkyCoder:
         return DraftResponse(text=code, file_content=None)
 
 
-CODER_SESSION = GrokkyCoder()
+CODER_SESSION = IndianaCoder()
 
 
 async def interpret_code(prompt: str) -> str:
@@ -113,4 +113,4 @@ async def generate_code(request: str) -> DraftResponse:
     return await CODER_SESSION.draft(request)
 
 
-__all__ = ["interpret_code", "generate_code", "GrokkyCoder", "DraftResponse"]
+__all__ = ["interpret_code", "generate_code", "IndianaCoder", "DraftResponse"]


### PR DESCRIPTION
## Summary
- rename GrokkyCoder to IndianaCoder in utils, tests, and docs
- ensure code references match new Indiana naming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `pytest tests/test_coder.py -q`
- `flake8 utils/coder.py tests/test_coder.py`


------
https://chatgpt.com/codex/tasks/task_e_6899f5ecfb608329b5df2ec102131121