### PR TITLE
Handle daily log metadata with Pinecone fetch compatibility

### DIFF
--- a/tests/test_dayandnight.py
+++ b/tests/test_dayandnight.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.vectorstore import LocalVectorStore  # noqa: E402
+from utils import dayandnight  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_store_and_fetch_last_day(monkeypatch):
+    store = LocalVectorStore()
+    monkeypatch.setattr(dayandnight, "vector_store", store)
+    await dayandnight._store_last_day("2024-01-01", "hi")
+    last = await dayandnight._fetch_last_day()
+    assert last == "2024-01-01"


### PR DESCRIPTION
## Summary
- Fix daily log retrieval by accommodating Pinecone's FetchResponse and local store formats
- Store reflection date metadata in vector store for reliable daily checks
- Add regression test for storing and fetching last daily log

## Testing
- `python -m flake8 utils/dayandnight.py utils/vectorstore.py tests/test_dayandnight.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts', etc.)*
- `pytest tests/test_dayandnight.py`

------
https://chatgpt.com/codex/tasks/task_e_6899f999c01c8329bd17893b75f4b47e