### PR TITLE
Limit vector store size and ensure eviction

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ client = AsyncOpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 # Will be filled at startup
 ASSISTANT_ID = None
 
-vector_store = create_vector_store()
+vector_store = create_vector_store(max_size=1000)
 memory = MemoryManager(db_path="lighthouse_memory.db", vectorstore=vector_store)
 # Lower the likelihood of spontaneous additions
 AFTERTHOUGHT_CHANCE = 0.02

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -1,0 +1,22 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.vectorstore import LocalVectorStore  # noqa: E402
+
+
+def test_local_vector_store_eviction():
+    store = LocalVectorStore(max_size=2)
+
+    async def _populate():
+        await store.store("1", "text1")
+        await store.store("2", "text2")
+        await store.store("3", "text3")
+
+    asyncio.run(_populate())
+
+    # Oldest entry should be evicted
+    assert "1" not in store._store
+    assert list(store._store.keys()) == ["2", "3"]

--- a/utils/dayandnight.py
+++ b/utils/dayandnight.py
@@ -7,7 +7,7 @@ from openai import AsyncOpenAI
 from .vectorstore import create_vector_store
 from .config import settings
 
-vector_store = create_vector_store()
+vector_store = create_vector_store(max_size=1000)
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None
 logger = logging.getLogger(__name__)
 

--- a/utils/knowtheworld.py
+++ b/utils/knowtheworld.py
@@ -13,7 +13,7 @@ from .memory import MemoryManager
 from .config import settings
 
 
-vector_store = create_vector_store()
+vector_store = create_vector_store(max_size=1000)
 memory = MemoryManager(db_path="lighthouse_memory.db", vectorstore=vector_store)
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None
 logger = logging.getLogger(__name__)

--- a/utils/vectorstore.py
+++ b/utils/vectorstore.py
@@ -87,8 +87,18 @@ else:  # pragma: no cover - optional
 
 
 class LocalVectorStore(BaseVectorStore):
-    def __init__(self, max_size: int | None = None, persist_path: str | None = None):
-        """In-memory vector store with optional size limit and persistence."""
+    def __init__(self, max_size: int | None = 1000, persist_path: str | None = None):
+        """In-memory vector store with optional size limit and persistence.
+
+        Parameters
+        ----------
+        max_size:
+            Maximum number of entries to retain. A sane default of ``1000`` is
+            used to avoid unbounded memory growth. Pass ``None`` to disable the
+            limit entirely.
+        persist_path:
+            Optional path to persist the store on shutdown.
+        """
         self.max_size = max_size
         self.persist_path = persist_path
         # store as OrderedDict {id: (text, user_id)} to track insertion order
@@ -130,7 +140,7 @@ class LocalVectorStore(BaseVectorStore):
         return [text for text, _ in scored[:top_k]]
 
 
-def create_vector_store(max_size: int | None = None, persist_path: str | None = None) -> BaseVectorStore:
+def create_vector_store(max_size: int | None = 1000, persist_path: str | None = None) -> BaseVectorStore:
     if (
         Pinecone
         and settings.OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- default LocalVectorStore to a bounded size of 1000 items and document the behavior
- explicitly pass `max_size` when creating vector stores in main, day-and-night and know-the-world modules
- add test verifying oldest entries are evicted when the limit is exceeded

## Testing
- `flake8 main.py utils/vectorstore.py utils/dayandnight.py utils/knowtheworld.py tests/test_vectorstore.py`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f9aa4b3c832991687850ff2cc5e7