### PR TITLE
Implement rate limiting for handle_message

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,43 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import RATE_LIMIT, USER_MESSAGE_TIMES, handle_message, is_rate_limited  # noqa: E402
+
+
+class DummyMessage:
+    def __init__(self):
+        self.text = "Hello?"
+        self.from_user = SimpleNamespace(id=123, language_code="en")
+        self.chat = SimpleNamespace(id=123, type="private")
+        self.voice = None
+        self.photo = []
+        self.answers: list[str] = []
+
+    async def answer(self, text: str):
+        self.answers.append(text)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_stops_responses(monkeypatch):
+    USER_MESSAGE_TIMES._data.clear()
+    user_id = str(123)
+    for _ in range(RATE_LIMIT):
+        assert not is_rate_limited(user_id)
+
+    m = DummyMessage()
+
+    async def fake_send_split_message(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("send_split_message should not be called")
+
+    monkeypatch.setattr("main.send_split_message", fake_send_split_message)
+
+    await handle_message(m)
+
+    assert m.answers, "warning should be sent when rate limit exceeded"
+    assert "слишком часто" in m.answers[0].lower()


### PR DESCRIPTION
## Summary
- track recent message timestamps and enforce 5-per-minute limit
- warn and ignore messages once limit is exceeded
- add test ensuring responses stop after limit is hit

## Testing
- `flake8 main.py tests/test_rate_limit.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'server')*
- `pytest tests/test_rate_limit.py`


------
https://chatgpt.com/codex/tasks/task_e_6899f9ed56248329be550e0459a9c0e5