### PR TITLE
feat: add per-user rate limiting middleware

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from langdetect import detect, DetectorFactory
 from utils.repo_monitor import RepoWatcher
 from utils.voice import text_to_voice, voice_to_text
 from utils.context_neural_processor import parse_and_store_file
+from utils.rate_limiter import RateLimitMiddleware
 
 # Настройка логгера
 logging.basicConfig(level=logging.INFO)
@@ -64,6 +65,13 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher()
+dp.message.middleware(
+    RateLimitMiddleware(
+        settings.RATE_LIMIT_COUNT,
+        settings.RATE_LIMIT_PERIOD,
+        settings.RATE_LIMIT_DELAY,
+    )
+)
 
 # --- OpenAI Client ---
 client = AsyncOpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
@@ -389,7 +397,7 @@ async def process_with_assistant(prompt: str, context: str = "", language: str =
                 if message.role == "assistant":
                     response_text = message.content[0].text.value
                     # Проверяем, что ответ не обрезан посередине предложения
-                    if response_text and not response_text[-1] in ['.', '!', '?', ':', ';', '"', ')', ']', '}']:
+                    if response_text and response_text[-1] not in ['.', '!', '?', ':', ';', '"', ')', ']', '}']:
                         # Если ответ обрезан, добавляем многоточие
                         logger.warning("Response appears to be cut off mid-sentence")
                         response_text += "..."

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from aiogram.types import Chat, Message, User
+
+from utils.rate_limiter import RateLimitMiddleware
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_blocks_excess_messages():
+    middleware = RateLimitMiddleware(limit=2, window=60, delay=0)
+    user = User(id=1, is_bot=False, first_name="Test")
+    chat = Chat(id=1, type="private")
+    message = Message(message_id=1, date=datetime.now(), chat=chat, from_user=user, text="hello")
+
+    calls = 0
+
+    async def handler(event, data):
+        nonlocal calls
+        calls += 1
+
+    await middleware(handler, message, {})
+    await middleware(handler, message, {})
+    await middleware(handler, message, {})
+
+    assert calls == 2

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,5 +14,8 @@ class Settings:
     GROUP_CHAT: str = os.getenv("GROUP_CHAT", "")
     CREATOR_CHAT: str = os.getenv("CREATOR_CHAT", "")
     PPLX_API_KEY: str = os.getenv("PPLX_API_KEY", os.getenv("PERPLEXITY_API_KEY", ""))
+    RATE_LIMIT_COUNT: int = int(os.getenv("RATE_LIMIT_COUNT", 20))
+    RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
+    RATE_LIMIT_DELAY: float = float(os.getenv("RATE_LIMIT_DELAY", 0))
 
 settings = Settings()

--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -1,0 +1,48 @@
+import asyncio
+import logging
+import time
+from collections import deque
+from typing import Deque, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message, TelegramObject
+
+from .lru_cache import LRUCache
+
+
+class RateLimitMiddleware(BaseMiddleware):
+    """Simple per-user rate limiter.
+
+    Keeps a rolling window of message timestamps for each user and ensures
+    that no more than ``limit`` messages are processed within ``window``
+    seconds. When the limit is exceeded, the message is ignored or delayed
+    depending on ``delay``.
+    """
+
+    def __init__(self, limit: int, window: float, delay: float = 0.0, max_users: int = 1024) -> None:
+        self.limit = limit
+        self.window = window
+        self.delay = delay
+        self._users: LRUCache = LRUCache(maxlen=max_users)
+        self.logger = logging.getLogger(__name__)
+
+    async def __call__(self, handler, event: TelegramObject, data: Dict):  # type: ignore[override]
+        if isinstance(event, Message) and event.from_user:
+            user_id = str(event.from_user.id)
+            now = time.time()
+            timestamps: Deque[float] = self._users.get(user_id, deque())
+
+            # drop outdated timestamps
+            while timestamps and now - timestamps[0] > self.window:
+                timestamps.popleft()
+
+            if len(timestamps) >= self.limit:
+                self.logger.warning("Rate limit exceeded for user %s", user_id)
+                if self.delay > 0:
+                    await asyncio.sleep(self.delay)
+                    return await handler(event, data)
+                return None
+
+            timestamps.append(now)
+            self._users.set(user_id, timestamps)
+        return await handler(event, data)


### PR DESCRIPTION
## Summary
- add configurable per-user rate limiting middleware
- register middleware for all incoming messages
- cover rate limiting behavior with test

## Testing
- `ruff check utils/rate_limiter.py utils/config.py main.py tests/test_rate_limiter.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `pytest tests/test_rate_limiter.py`

------
https://chatgpt.com/codex/tasks/task_e_6899fb0167d88329b1da7c0d3a3fd2d9