### PR TITLE
feat: configure vector store size

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ client = AsyncOpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 # Will be filled at startup
 ASSISTANT_ID = None
 
-vector_store = create_vector_store(max_size=1000)
+vector_store = create_vector_store(max_size=settings.VECTOR_STORE_MAX_SIZE)
 memory = MemoryManager(db_path="lighthouse_memory.db", vectorstore=vector_store)
 # Lower the likelihood of spontaneous additions
 AFTERTHOUGHT_CHANCE = 0.02

--- a/utils/config.py
+++ b/utils/config.py
@@ -17,5 +17,6 @@ class Settings:
     RATE_LIMIT_COUNT: int = int(os.getenv("RATE_LIMIT_COUNT", 20))
     RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
     RATE_LIMIT_DELAY: float = float(os.getenv("RATE_LIMIT_DELAY", 0))
+    VECTOR_STORE_MAX_SIZE: int = int(os.getenv("VECTOR_STORE_MAX_SIZE", 1000))
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- make vector store max size configurable via settings
- persist LocalVectorStore asynchronously with eviction
- pass configured max size during vector store initialization

## Testing
- `flake8 utils/vectorstore.py utils/config.py main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'server')*


------
https://chatgpt.com/codex/tasks/task_e_689a01805aac8329bff5236b2735d493