### PR TITLE
Add state tracking for data collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,4 +215,5 @@ lighthouse_memory.db
 GENESIS_orchestrator/gen_data.txt
 GENESIS_orchestrator/weights/
 GENESIS_orchestrator/data/
+GENESIS_orchestrator/state.json
 

--- a/GENESIS_orchestrator/state.py
+++ b/GENESIS_orchestrator/state.py
@@ -1,0 +1,24 @@
+import json
+import hashlib
+from pathlib import Path
+from typing import Dict, Any
+
+STATE_FILE = Path(__file__).with_name('state.json')
+
+def load_state() -> Dict[str, Any]:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+def save_state(state: Dict[str, Any]) -> None:
+    STATE_FILE.write_text(json.dumps(state))
+
+def file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 
 import pytest
-
-import sys
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from GENESIS_orchestrator.symphony import collect_new_data, markov_entropy
 
 def test_markov_entropy_simple():
@@ -45,3 +42,18 @@ def test_collect_new_data_excludes_dataset(tmp_path):
     ready, data = collect_new_data([tmp_path], dataset, threshold=1)
     assert ready is True
     assert "old" not in data
+
+
+def test_collect_new_data_resume(tmp_path, monkeypatch):
+    from GENESIS_orchestrator import state as state_module
+    monkeypatch.setattr(state_module, "STATE_FILE", tmp_path / "state.json")
+
+    file = tmp_path / "sample.txt"
+    file.write_text("hello world")
+
+    ready, _ = collect_new_data([tmp_path], tmp_path / "out.txt", threshold=1, resume=True)
+    assert ready is True
+
+    ready, data = collect_new_data([tmp_path], tmp_path / "out.txt", threshold=1, resume=True)
+    assert ready is False
+    assert data == ""


### PR DESCRIPTION
## Summary
- track processed file hashes and sizes in new `state.py`
- skip unchanged files in `collect_new_data` and add `--resume` CLI flag
- cover resume behaviour with tests

## Testing
- `flake8 GENESIS_orchestrator/symphony.py GENESIS_orchestrator/state.py tests/test_symphony.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9693181c832987e3d8d51bf787a4