### PR TITLE
Add streaming entropy module and CLI n-gram order option

### DIFF
--- a/GENESIS_orchestrator/entropy.py
+++ b/GENESIS_orchestrator/entropy.py
@@ -1,0 +1,57 @@
+from collections import Counter
+from collections.abc import Iterable
+import math
+from typing import Generator
+
+
+def ngram_counter(stream: Iterable[str], n: int) -> Generator[Counter[str], None, None]:
+    """Yield cumulative n-gram counts for chunks from the stream.
+
+    Parameters
+    ----------
+    stream: Iterable[str]
+        Iterable producing pieces of text.
+    n: int
+        Order of the n-grams to count. Must be positive.
+
+    Yields
+    ------
+    Counter[str]
+        Cumulative counts of observed n-grams after processing each chunk.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    counts: Counter[str] = Counter()
+    buffer = ""
+    for chunk in stream:
+        if not isinstance(chunk, str):
+            raise TypeError("stream must yield strings")
+        data = buffer + chunk
+        if len(data) >= n:
+            for i in range(len(data) - n + 1):
+                counts[data[i:i + n]] += 1
+            buffer = data[-(n - 1):] if n > 1 else ""
+        else:
+            buffer = data
+        yield counts.copy()
+
+
+def markov_entropy(text: str | Iterable[str], n: int = 2) -> float:
+    """Compute Shannon entropy of character n-grams in ``text``.
+
+    ``text`` may be a single string or an iterable producing strings.
+    """
+    if isinstance(text, str):
+        stream: Iterable[str] = [text]
+    elif isinstance(text, Iterable):
+        stream = text
+    else:
+        raise TypeError("text must be a string or an iterable of strings")
+
+    final_counts: Counter[str] | None = None
+    for counts in ngram_counter(stream, n):
+        final_counts = counts
+    if not final_counts:
+        return 0.0
+    total = sum(final_counts.values())
+    return -sum((c / total) * math.log2(c / total) for c in final_counts.values())

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-
 import pytest
 
-import sys
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-from GENESIS_orchestrator.symphony import collect_new_data, markov_entropy
+from GENESIS_orchestrator.entropy import markov_entropy, ngram_counter
+from GENESIS_orchestrator.symphony import collect_new_data
 
 def test_markov_entropy_simple():
     text = "abab"
@@ -19,6 +16,20 @@ def test_markov_entropy_empty_and_short():
 def test_markov_entropy_non_string():
     with pytest.raises(TypeError):
         markov_entropy(123)  # type: ignore[arg-type]
+
+
+def test_ngram_counter_stream():
+    stream = ["aba", "ba"]
+    gen = ngram_counter(stream, n=2)
+    first = next(gen)
+    assert first == {"ab": 1, "ba": 1}
+    second = next(gen)
+    assert second == {"ab": 2, "ba": 2}
+
+
+def test_markov_entropy_stream():
+    stream = ["ab", "ab"]
+    assert round(markov_entropy(stream, n=2), 2) == 0.92
 
 def test_collect_new_data(tmp_path):
     file = tmp_path / "sample.txt"


### PR DESCRIPTION
## Summary
- Extract entropy logic into new `entropy.py` with `ngram_counter` generator and streaming `markov_entropy`
- Update `symphony` to use the new module and expose `--order` CLI parameter
- Extend tests to cover streaming n-gram counting and entropy

## Testing
- `flake8` *(fails: AM-Linux-Core/bridge.py:104:44: E203 whitespace before ':')*
- `flake8 GENESIS_orchestrator/entropy.py GENESIS_orchestrator/symphony.py tests/test_symphony.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a96a7c064832990f26db464e0e872