### PR TITLE
feat: add trainer config and logging

### DIFF
--- a/GENESIS_orchestrator/symphony.py
+++ b/GENESIS_orchestrator/symphony.py
@@ -1,14 +1,48 @@
 import argparse
 import json
+import logging
 import math
 import sys
 import subprocess
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Tuple
 
+import yaml
+
 DATASET_FILE = Path(__file__).with_name('gen_data.txt')
 DEFAULT_THRESHOLD = 256 * 1024  # 256KB
+
+
+@dataclass
+class TrainerConfig:
+    compile: bool = False
+    eval_iters: int = 1
+    log_interval: int = 1
+    block_size: int = 64
+    batch_size: int = 12
+    n_layer: int = 2
+    n_head: int = 2
+    n_embd: int = 64
+    max_iters: int = 10
+    lr_decay_iters: int = 10
+    dropout: float = 0.0
+    out_dir: str = 'weights'
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> 'TrainerConfig':
+        with path.open('r', encoding='utf-8') as f:
+            data = yaml.safe_load(f) or {}
+        return cls(**data)
+
+
+def _detect_device() -> str:
+    try:
+        import torch
+        return 'cuda' if torch.cuda.is_available() else 'cpu'
+    except Exception:
+        return 'cpu'
 
 def _looks_binary(path: Path) -> bool:
     try:
@@ -70,33 +104,53 @@ def _prepare_char_dataset(text: str, dest: Path) -> None:
     with open(dest / 'meta.pkl', 'wb') as f:
         pickle.dump(meta, f)
 
-def train_model(dataset_dir: Path, out_dir: Path) -> None:
+def train_model(dataset_dir: Path, config: TrainerConfig) -> None:
     if not dataset_dir.exists():
         print('dataset not found, skipping training')
         return
-    weights_dir = out_dir
+    device = _detect_device()
+    weights_dir = Path(__file__).parent / config.out_dir
     weights_dir.mkdir(parents=True, exist_ok=True)
     cmd = [
         sys.executable,
         'train.py',
         f'--dataset={dataset_dir.name}',
-        '--device=cpu',
-        '--compile=False',
-        '--eval_iters=1',
-        '--log_interval=1',
-        '--block_size=64',
-        '--batch_size=12',
-        '--n_layer=2',
-        '--n_head=2',
-        '--n_embd=64',
-        '--max_iters=10',
-        '--lr_decay_iters=10',
-        '--dropout=0.0',
+        f'--device={device}',
+        f'--compile={str(config.compile)}',
+        f'--eval_iters={config.eval_iters}',
+        f'--log_interval={config.log_interval}',
+        f'--block_size={config.block_size}',
+        f'--batch_size={config.batch_size}',
+        f'--n_layer={config.n_layer}',
+        f'--n_head={config.n_head}',
+        f'--n_embd={config.n_embd}',
+        f'--max_iters={config.max_iters}',
+        f'--lr_decay_iters={config.lr_decay_iters}',
+        f'--dropout={config.dropout}',
         f'--out_dir={weights_dir}',
     ]
+    logger = logging.getLogger('genesis_train')
+    if not logger.handlers:
+        logs_dir = Path(__file__).resolve().parents[1] / 'logs'
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        handler = logging.FileHandler(logs_dir / 'genesis_train.log')
+        handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s'))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
     try:
-        subprocess.run(cmd, cwd=Path(__file__).parent, check=True)
+        result = subprocess.run(
+            cmd,
+            cwd=Path(__file__).parent,
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout:
+            logger.info(result.stdout)
+        if result.stderr:
+            logger.error(result.stderr)
+        result.check_returncode()
     except Exception as exc:
+        logger.exception('training failed: %s', exc)
         print(f'training failed: {exc}')
 
 def main() -> None:
@@ -112,7 +166,9 @@ def main() -> None:
     if ready and not args.dry_run:
         dataset_dir = Path(__file__).parent / 'data' / 'genesis'
         _prepare_char_dataset(text, dataset_dir)
-        train_model(dataset_dir, Path(__file__).parent / 'weights')
+        config_path = Path(__file__).resolve().parents[1] / 'config' / 'genesis.yaml'
+        config = TrainerConfig.from_yaml(config_path)
+        train_model(dataset_dir, config)
 
 if __name__ == '__main__':
     main()

--- a/config/genesis.yaml
+++ b/config/genesis.yaml
@@ -1,0 +1,12 @@
+compile: false
+eval_iters: 1
+log_interval: 1
+block_size: 64
+batch_size: 12
+n_layer: 2
+n_head: 2
+n_embd: 64
+max_iters: 10
+lr_decay_iters: 10
+dropout: 0.0
+out_dir: weights


### PR DESCRIPTION
## Summary
- load training hyperparameters from `config/genesis.yaml`
- build train command using `TrainerConfig` with auto device detection
- capture training output with logging to `logs/genesis_train.log`

## Testing
- `flake8 GENESIS_orchestrator/symphony.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a96ce47548329bb3c72346020d413