### PR TITLE
Improve state persistence with versioning

### DIFF
--- a/GENESIS_orchestrator/state.py
+++ b/GENESIS_orchestrator/state.py
@@ -1,20 +1,69 @@
 import json
 import hashlib
+import logging
 from pathlib import Path
 from typing import Dict, Any
 
 STATE_FILE = Path(__file__).with_name('state.json')
+STATE_VERSION = 1
 
-def load_state() -> Dict[str, Any]:
-    if STATE_FILE.exists():
-        try:
-            return json.loads(STATE_FILE.read_text())
-        except Exception:
-            return {}
+logger = logging.getLogger(__name__)
+
+def _migrate_state(data: Dict[str, Any], version: int) -> Dict[str, Any]:
+    """Migrate legacy state formats to the current structure.
+
+    Version ``0`` stored the file mapping directly without a version key.
+    """
+    if version == 0:
+        return data if isinstance(data, dict) else {}
+    logger.warning("no migration path for state version %s", version)
     return {}
 
+def load_state() -> Dict[str, Any]:
+    """Load the state file.
+
+    Returns the mapping of file paths to hash/size information. If the file is
+    missing, unreadable or incompatible, an empty mapping is returned.
+    """
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        data = json.loads(STATE_FILE.read_text())
+    except Exception as exc:
+        logger.error("failed to read state file %s: %s", STATE_FILE, exc)
+        return {}
+    if isinstance(data, dict) and 'version' in data:
+        version = data.get('version', 0)
+        if version == STATE_VERSION:
+            files = data.get('files', {})
+            return files if isinstance(files, dict) else {}
+        if version < STATE_VERSION:
+            try:
+                return _migrate_state(data, version)
+            except Exception as exc:
+                logger.error("failed to migrate state: %s", exc)
+                return {}
+        logger.warning("unsupported state version %s", version)
+        return {}
+    return data if isinstance(data, dict) else {}
+
 def save_state(state: Dict[str, Any]) -> None:
-    STATE_FILE.write_text(json.dumps(state))
+    """Persist state atomically.
+
+    The state is wrapped with a version header and written to a temporary file
+    before being atomically renamed into place.
+    """
+    tmp_path = STATE_FILE.with_suffix('.tmp')
+    data = {'version': STATE_VERSION, 'files': state}
+    try:
+        tmp_path.write_text(json.dumps(data))
+        tmp_path.replace(STATE_FILE)
+    except Exception as exc:
+        logger.error("failed to save state file %s: %s", STATE_FILE, exc)
+        try:
+            tmp_path.unlink()
+        except Exception:
+            pass
 
 def file_hash(path: Path) -> str:
     h = hashlib.sha256()

--- a/GENESIS_orchestrator/state_format.md
+++ b/GENESIS_orchestrator/state_format.md
@@ -1,0 +1,20 @@
+# `state.json` Format
+
+The orchestrator stores information about processed files in a JSON file located
+next to the module. The document structure is:
+
+```json
+{
+  "version": 1,
+  "files": {
+    "/absolute/path": {"hash": "<sha256>", "size": 123}
+  }
+}
+```
+
+* `version` – schema version to allow future migrations.
+* `files` – mapping of file paths to their SHA256 hash and byte size.
+
+Legacy files without a `version` key are treated as **version 0** and consist of
+just the `files` mapping. The loader automatically migrates these files when
+reading.


### PR DESCRIPTION
## Summary
- add logging and error handling for state load/save
- write state.json atomically and track schema version
- document state.json format

## Testing
- `python -m flake8` (fails: E203 whitespace before ':' ...)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9ce4ceb48329ab575b55dfcf0dbd