### PR TITLE
Adapt training for CPU and CLI args

### DIFF
--- a/GENESIS_orchestrator/train.py
+++ b/GENESIS_orchestrator/train.py
@@ -16,6 +16,7 @@ $ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123
 (If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
 """
 
+import argparse
 import os
 import time
 import math
@@ -84,8 +85,39 @@ dropout = model_hyperparams.get('dropout', dropout)
 max_iters = model_hyperparams.get('max_iters', max_iters)
 lr_decay_iters = model_hyperparams.get('lr_decay_iters', lr_decay_iters)
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--out_dir', type=str, default=out_dir)
+parser.add_argument('--dataset', type=str, default=dataset)
+parser.add_argument('--device', type=str, default=device)
+parser.add_argument('--compile', type=lambda x: str(x).lower() == 'true', default=compile)
+parser.add_argument('--eval_iters', type=int, default=eval_iters)
+parser.add_argument('--log_interval', type=int, default=log_interval)
+parser.add_argument('--block_size', type=int, default=block_size)
+parser.add_argument('--batch_size', type=int, default=batch_size)
+parser.add_argument('--n_layer', type=int, default=n_layer)
+parser.add_argument('--n_head', type=int, default=n_head)
+parser.add_argument('--n_embd', type=int, default=n_embd)
+parser.add_argument('--max_iters', type=int, default=max_iters)
+parser.add_argument('--lr_decay_iters', type=int, default=lr_decay_iters)
+parser.add_argument('--dropout', type=float, default=dropout)
+args = parser.parse_args()
+
+out_dir = args.out_dir
+dataset = args.dataset
+device = args.device
+compile = args.compile
+eval_iters = args.eval_iters
+log_interval = args.log_interval
+block_size = args.block_size
+batch_size = args.batch_size
+n_layer = args.n_layer
+n_head = args.n_head
+n_embd = args.n_embd
+max_iters = args.max_iters
+lr_decay_iters = args.lr_decay_iters
+dropout = args.dropout
+
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
-exec(open('configurator.py').read()) # overrides from command line or config file
 config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 

--- a/tests/test_train_cpu.py
+++ b/tests/test_train_cpu.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from GENESIS_orchestrator import symphony  # noqa: E402
+
+
+def test_train_model_uses_cpu(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, cwd=None, check=False):
+        captured['cmd'] = cmd
+
+    monkeypatch.setattr(symphony.subprocess, 'run', fake_run)
+    dataset = tmp_path / 'data'
+    dataset.mkdir()
+    symphony.train_model(dataset, tmp_path / 'out')
+    cmd = captured['cmd']
+    assert '--device=cpu' in cmd
+    assert '--block_size=32' in cmd
+    assert '--batch_size=4' in cmd
+    assert '--n_layer=1' in cmd
+    assert '--n_head=1' in cmd
+    assert '--n_embd=32' in cmd


### PR DESCRIPTION
## Summary
- detect CUDA availability in training orchestrator and scale model down on CPU
- parse training hyperparameters from CLI arguments in `train.py`
- add test ensuring training command uses CPU-friendly defaults

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_train_cpu.py`
- `flake8 GENESIS_orchestrator/train.py` *(fails: E261 before inline comment, etc.)*
- `pytest tests/test_train_cpu.py -q`
- `pytest tests/test_symphony.py -q`
- `pytest` *(fails: KeyboardInterrupt: /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/urllib3/util/retry.py:347)*

------
https://chatgpt.com/codex/tasks/task_e_689a9e60302083299ab13fe30c65fb8f