### PR TITLE
feat: report neural entropy alongside markov metric

### DIFF
--- a/GENESIS_orchestrator/symphony.py
+++ b/GENESIS_orchestrator/symphony.py
@@ -2,6 +2,8 @@ import argparse
 import json
 import logging
 import math
+import pickle
+import shutil
 import subprocess
 import sys
 from collections import Counter
@@ -89,6 +91,52 @@ def markov_entropy(text: str, n: int = 2) -> float:
     total = sum(counts.values())
     return -sum((c / total) * math.log2(c / total) for c in counts.values())
 
+
+def model_perplexity(text: str) -> float:
+    """Return the perplexity of ``text`` under the trained mini-GPT model.
+
+    The function loads the checkpoint produced by :func:`train_model` from the
+    ``weights`` directory and evaluates the cross-entropy loss on the provided
+    ``text``. Perplexity is ``exp(loss)``. If no model weights are available or
+    the text is too short, ``0.0`` is returned.
+    """
+
+    weights_path = Path(__file__).with_name("weights") / "model.pth"
+    if not text or not weights_path.exists():
+        return 0.0
+
+    try:
+        import torch
+
+        checkpoint = torch.load(weights_path, map_location="cpu")
+    except Exception:
+        return 0.0
+
+    model_args = checkpoint.get("model_args")
+    if not model_args:
+        return 0.0
+
+    from .model import GPT, GPTConfig
+
+    model = GPT(GPTConfig(**model_args))
+    model.load_state_dict(checkpoint["model"])
+    model.eval()
+
+    try:
+        with open(Path(CONFIG_DATASET_DIR) / "meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        stoi = meta["stoi"]
+    except Exception:
+        return 0.0
+
+    encoded = [stoi.get(ch, 0) for ch in text]
+    if len(encoded) < 2:
+        return 0.0
+    ids = torch.tensor(encoded, dtype=torch.long).unsqueeze(0)
+    with torch.no_grad():
+        _, loss = model(ids[:, :-1], ids[:, 1:])
+    return float(math.exp(loss.item()))
+
 def _prepare_char_dataset(text: str, dest: Path) -> None:
     import pickle
     import numpy as np
@@ -127,8 +175,32 @@ def train_model(dataset_dir: Path, out_dir: Path) -> None:
     cmd.append(f'--out_dir={weights_dir}')
     try:
         subprocess.run(cmd, cwd=Path(__file__).parent, check=True)
+        ckpt = weights_dir / 'ckpt.pt'
+        if ckpt.exists():
+            shutil.copy(ckpt, weights_dir / 'model.pth')
     except Exception as exc:
         print(f'training failed: {exc}')
+
+
+def run_orchestrator(
+    threshold: int = DEFAULT_THRESHOLD,
+    dataset_dir: Path = CONFIG_DATASET_DIR,
+    resume: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Collect data, train if ready, and return entropy metrics."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    base_paths = [repo_root / 'artefacts', repo_root]
+    ready, text = collect_new_data(base_paths, DATASET_FILE, threshold, resume=resume)
+    metrics = {
+        'markov_entropy': round(markov_entropy(text), 2),
+        'model_perplexity': round(model_perplexity(text), 2),
+    }
+    if ready and not dry_run:
+        _prepare_char_dataset(text, dataset_dir)
+        train_model(dataset_dir, Path(__file__).parent / 'weights')
+    return metrics
 
 def main() -> None:
     parser = argparse.ArgumentParser()
@@ -136,16 +208,24 @@ def main() -> None:
     parser.add_argument('--dataset_dir', type=str, default=str(CONFIG_DATASET_DIR))
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('--resume', action='store_true')
+    parser.add_argument(
+        '--metric', choices=['markov', 'neural', 'both'], default='both'
+    )
     args = parser.parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
-    base_paths = [repo_root / 'artefacts', repo_root]
-    ready, text = collect_new_data(base_paths, DATASET_FILE, args.threshold, resume=args.resume)
-    entropy = markov_entropy(text)
-    print(json.dumps({'markov_entropy': round(entropy, 2)}))
-    if ready and not args.dry_run:
-        dataset_dir = Path(args.dataset_dir)
-        _prepare_char_dataset(text, dataset_dir)
-        train_model(dataset_dir, Path(__file__).parent / 'weights')
+
+    metrics = run_orchestrator(
+        threshold=args.threshold,
+        dataset_dir=Path(args.dataset_dir),
+        resume=args.resume,
+        dry_run=args.dry_run,
+    )
+    if args.metric == 'markov':
+        out = {'markov_entropy': metrics['markov_entropy']}
+    elif args.metric == 'neural':
+        out = {'model_perplexity': metrics['model_perplexity']}
+    else:
+        out = metrics
+    print(json.dumps(out))
 
 if __name__ == '__main__':
     main()

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -51,6 +51,21 @@ def test_collect_new_data_without_threshold(tmp_path):
     assert not dataset.exists()
 
 
+def test_run_orchestrator_returns_metrics(monkeypatch, tmp_path):
+    from GENESIS_orchestrator import symphony
+
+    monkeypatch.setattr(
+        symphony, "collect_new_data", lambda *a, **k: (False, "abc")
+    )
+    monkeypatch.setattr(symphony, "markov_entropy", lambda text: 1.0)
+    monkeypatch.setattr(symphony, "model_perplexity", lambda text: 2.0)
+    monkeypatch.setattr(symphony, "_prepare_char_dataset", lambda *a, **k: None)
+    monkeypatch.setattr(symphony, "train_model", lambda *a, **k: None)
+
+    metrics = symphony.run_orchestrator(dataset_dir=tmp_path)
+    assert metrics == {"markov_entropy": 1.0, "model_perplexity": 2.0}
+
+
 def test_main_reads_config_and_cli_override(monkeypatch, tmp_path):
     from GENESIS_orchestrator import symphony
 


### PR DESCRIPTION
## Summary
- save trained mini-GPT weights to `GENESIS_orchestrator/weights/model.pth`
- add `model_perplexity` to evaluate neural perplexity from saved weights
- expose both Markov entropy and neural perplexity via `run_orchestrator`
- support selecting desired metric from the CLI

## Testing
- `python -m flake8 GENESIS_orchestrator/symphony.py tests/test_symphony.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9f03edac8329aee0ba85d035442d