### PR TITLE
Track file offsets for incremental dataset growth

### DIFF
--- a/GENESIS_orchestrator/state_format.md
+++ b/GENESIS_orchestrator/state_format.md
@@ -7,13 +7,14 @@ next to the module. The document structure is:
 {
   "version": 1,
   "files": {
-    "/absolute/path": {"hash": "<sha256>", "size": 123}
+    "/absolute/path": {"hash": "<sha256>", "size": 123, "offset": 123}
   }
 }
 ```
 
 * `version` – schema version to allow future migrations.
-* `files` – mapping of file paths to their SHA256 hash and byte size.
+* `files` – mapping of file paths to their SHA256 hash, byte size and the
+  offset up to which data has already been incorporated.
 
 Legacy files without a `version` key are treated as **version 0** and consist of
 just the `files` mapping. The loader automatically migrates these files when


### PR DESCRIPTION
## Summary
- Append new text to the dataset on every run and track file offsets to prevent duplicate reads
- Document new `offset` field in the state file format
- Add regression test ensuring dataset content persists across runs

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_symphony.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa01c4d1083299571a070e80b41fc