### PR TITLE
Log training subprocess output and duration

### DIFF
--- a/tests/test_train_cpu.py
+++ b/tests/test_train_cpu.py
@@ -9,8 +9,15 @@ from GENESIS_orchestrator import symphony  # noqa: E402
 def test_train_model_uses_cpu(monkeypatch, tmp_path):
     captured = {}
 
-    def fake_run(cmd, cwd=None, check=False):
+    def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
         captured['cmd'] = cmd
+        captured['capture_output'] = capture_output
+        captured['text'] = text
+
+        class Result:
+            stdout = ''
+            stderr = ''
+        return Result()
 
     monkeypatch.setattr(symphony.subprocess, 'run', fake_run)
     dataset = tmp_path / 'data'
@@ -23,3 +30,5 @@ def test_train_model_uses_cpu(monkeypatch, tmp_path):
     assert '--n_layer=1' in cmd
     assert '--n_head=1' in cmd
     assert '--n_embd=32' in cmd
+    assert captured['capture_output'] is True
+    assert captured['text'] is True


### PR DESCRIPTION
## Summary
- capture and log training subprocess output via `subprocess.run(..., capture_output=True, text=True)`
- record training start/end with duration and failure handling
- validate CPU-training parameters and new capture flags in tests

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_train_cpu.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa04898a083299e2bca597a09026d