### PR TITLE
Validate char dataset input for empty text

### DIFF
--- a/GENESIS_orchestrator/symphony.py
+++ b/GENESIS_orchestrator/symphony.py
@@ -92,7 +92,11 @@ def markov_entropy(text: str, n: int = 2) -> float:
 def _prepare_char_dataset(text: str, dest: Path) -> None:
     import pickle
     import numpy as np
+
     chars = sorted(set(text))
+    if not text or not chars:
+        raise ValueError("text must be non-empty and contain at least one unique character")
+
     stoi = {ch: i for i, ch in enumerate(chars)}
     itos = {i: ch for i, ch in enumerate(chars)}
     n = len(text)

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from GENESIS_orchestrator.symphony import collect_new_data, markov_entropy  # noqa: E402
@@ -88,3 +90,10 @@ def test_main_reads_config_and_cli_override(monkeypatch, tmp_path):
     assert captured["threshold"] == 5
     assert captured["dataset_dir"] == tmp_path / "other"
     assert captured["train_dataset"] == tmp_path / "other"
+
+
+def test_prepare_char_dataset_empty_text_raises(tmp_path):
+    from GENESIS_orchestrator.symphony import _prepare_char_dataset
+
+    with pytest.raises(ValueError, match="non-empty"):
+        _prepare_char_dataset("", tmp_path)


### PR DESCRIPTION
## Summary
- validate `_prepare_char_dataset` input and raise a clear error if text is empty or lacks unique characters
- add regression test covering empty text scenario

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_symphony.py && echo flake8_ok`
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689aa03efca483298f2d30150b6b96f9