### PR TITLE
feat(orchestrator): add extension filters

### DIFF
--- a/GENESIS_orchestrator/state_format.md
+++ b/GENESIS_orchestrator/state_format.md
@@ -18,3 +18,11 @@ next to the module. The document structure is:
 Legacy files without a `version` key are treated as **version 0** and consist of
 just the `files` mapping. The loader automatically migrates these files when
 reading.
+
+## Extension Filtering
+
+`run_orchestrator` can filter which files are included during data collection.
+Use the command-line options `--allow-ext` and `--deny-ext` to specify allowed
+or disallowed file extensions. `--allow-ext` may be repeated and defaults to the
+set `{'.txt', '.md', '.py'}` when not provided. `--deny-ext` excludes files with
+the given extensions.


### PR DESCRIPTION
## Summary
- allow filtering collected files by extension via `allow_ext`/`deny_ext`
- expose new `--allow-ext` and `--deny-ext` CLI options for `symphony`
- document extension filtering in state_format.md and update tests

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_symphony.py`
- `pytest tests/test_symphony.py`


------
https://chatgpt.com/codex/tasks/task_e_689aac40973483299678ebbd4dccebd4