### PR TITLE
feat: train in process when torch available

### DIFF
--- a/tests/test_train_cpu.py
+++ b/tests/test_train_cpu.py
@@ -14,6 +14,8 @@ def test_train_model_uses_cpu(monkeypatch, tmp_path):
 
     from GENESIS_orchestrator import genesis_trainer
 
+    # Force fallback to subprocess by simulating missing torch
+    monkeypatch.setattr(genesis_trainer, 'torch', None)
     monkeypatch.setattr(genesis_trainer.subprocess, 'run', fake_run)
     dataset = tmp_path / 'data'
     dataset.mkdir()

--- a/tests/test_train_direct.py
+++ b/tests/test_train_direct.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_train_model_runs_in_process(monkeypatch, tmp_path):
+    from GENESIS_orchestrator import genesis_trainer
+
+    called = {}
+
+    def fake_run_training(dataset_dir, out_dir, device="cpu", hyperparams=None):
+        called["dataset"] = dataset_dir
+        called["out_dir"] = out_dir
+        called["device"] = device
+        called["hyperparams"] = hyperparams or {}
+
+    monkeypatch.setattr(genesis_trainer, "run_training", fake_run_training)
+    monkeypatch.setattr(genesis_trainer, "torch", object())
+
+    dataset = tmp_path / "data"
+    dataset.mkdir()
+
+    genesis_trainer.train_model(dataset, tmp_path / "out")
+
+    assert called["dataset"] == dataset
+    assert called["out_dir"] == tmp_path / "out"
+    assert called["device"] == "cpu"
+    assert "block_size" in called["hyperparams"]


### PR DESCRIPTION
## Summary
- add `run_training` to perform tiny GPT training directly in-process
- call `run_training` from `train_model` when torch is available, falling back to subprocess otherwise
- add tests covering both subprocess fallback and direct training paths

## Testing
- `flake8 GENESIS_orchestrator/genesis_trainer.py tests/test_train_cpu.py tests/test_train_direct.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aac2023dc8329890b08d5de61ce98