### PR TITLE
Refactor trainer to expose train_loop

### DIFF
--- a/tests/test_train_cpu.py
+++ b/tests/test_train_cpu.py
@@ -9,19 +9,19 @@ from GENESIS_orchestrator.genesis_trainer import train_model  # noqa: E402
 def test_train_model_uses_cpu(monkeypatch, tmp_path):
     captured = {}
 
-    def fake_run(cmd, cwd=None, check=False):
-        captured['cmd'] = cmd
+    def fake_train_loop(args):
+        captured['args'] = args
 
     from GENESIS_orchestrator import genesis_trainer
 
-    monkeypatch.setattr(genesis_trainer.subprocess, 'run', fake_run)
+    monkeypatch.setattr(genesis_trainer, 'train_loop', fake_train_loop)
     dataset = tmp_path / 'data'
     dataset.mkdir()
     train_model(dataset, tmp_path / 'out')
-    cmd = captured['cmd']
-    assert '--device=cpu' in cmd
-    assert '--block_size=32' in cmd
-    assert '--batch_size=4' in cmd
-    assert '--n_layer=1' in cmd
-    assert '--n_head=1' in cmd
-    assert '--n_embd=32' in cmd
+    args = captured['args']
+    assert args.device == 'cpu'
+    assert args.block_size == 32
+    assert args.batch_size == 4
+    assert args.n_layer == 1
+    assert args.n_head == 1
+    assert args.n_embd == 32


### PR DESCRIPTION
## Summary
- add `train_loop` with core training behavior and logging
- call `train_loop` directly from `train_model` instead of spawning a subprocess
- simplify CLI entrypoint to parse args and invoke `train_loop`
- adjust tests to patch `train_loop` and assert CPU hyperparameters

## Testing
- `flake8` *(fails: E203, W391, etc. in unrelated files)*
- `flake8 GENESIS_orchestrator/genesis_trainer.py`
- `flake8 tests/test_train_cpu.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aac9bdaac8329a4b536e5bcb39839