### PR TITLE
Stream data collection with buffered writes

### DIFF
--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -73,6 +73,18 @@ def test_collect_new_data_without_threshold(tmp_path):
     assert not dataset.exists()
 
 
+def test_collect_new_data_with_small_chunk(tmp_path):
+    file = tmp_path / "a.txt"
+    file.write_text("hello\nworld")
+    dataset = tmp_path / "out.txt"
+    ready, data = collect_new_data(
+        [tmp_path], dataset, threshold=1, chunk_size=1
+    )
+    assert ready is True
+    assert data == "hello\nworld"
+    assert dataset.read_text() == "hello\nworld"
+
+
 def test_run_orchestrator_returns_metrics(monkeypatch, tmp_path):
     from GENESIS_orchestrator import symphony
 


### PR DESCRIPTION
## Summary
- Stream file reads line-by-line in `collect_new_data` and buffer writes to dataset
- Add `chunk_size` parameter to control buffering and prevent large in-memory strings
- Cover buffered collection with new test for tiny chunk sizes

## Testing
- `flake8 GENESIS_orchestrator/symphony.py tests/test_symphony.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aae54feb8832980cf5a9ade3ca6cf