### PR TITLE
Integrate GENESIS orchestrator entropy tracking

### DIFF
--- a/GENESIS_orchestrator/__init__.py
+++ b/GENESIS_orchestrator/__init__.py
@@ -1,0 +1,72 @@
+"""Lightweight interface for the GENESIS orchestrator.
+
+Provides helper functions for updating the dataset, training the
+mini-model/Markov chain, and reporting the latest entropy value.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final
+
+from .symphony import run_orchestrator
+from .orchestrator import STATE_FILE, threshold as DEFAULT_THRESHOLD
+
+ENTROPY_FILE: Final[Path] = Path(__file__).with_name("last_entropy.json")
+_last_entropy: float = 0.0
+_status: str = ""
+
+
+def _read_entropy_file() -> float:
+    try:
+        return float(json.loads(ENTROPY_FILE.read_text()).get("markov_entropy", 0.0))
+    except Exception:
+        return 0.0
+
+
+def _write_entropy_file(value: float) -> None:
+    try:
+        ENTROPY_FILE.write_text(json.dumps({"markov_entropy": value}))
+    except Exception:
+        pass
+
+
+_last_entropy = _read_entropy_file()
+
+
+def update_and_train() -> None:
+    """Collect new repository data and retrain if needed.
+
+    On the very first run (when no state file exists) the entire repository is
+    ingested and training is triggered immediately.
+    """
+    global _last_entropy, _status
+    state_exists = STATE_FILE.exists()
+    _status = "⏳"
+    try:
+        metrics = run_orchestrator(
+            threshold=0 if not state_exists else DEFAULT_THRESHOLD,
+            resume=state_exists,
+        )
+        _last_entropy = float(metrics.get("markov_entropy", 0.0))
+        _write_entropy_file(_last_entropy)
+    finally:
+        _status = ""
+
+
+def report_entropy() -> float:
+    """Return the most recently computed Markov entropy."""
+    return _last_entropy
+
+
+def status_emoji() -> str:
+    """Return an hourglass emoji when a training update occurred.
+
+    The emoji is returned once per update and then cleared so subsequent calls
+    yield an empty string.
+    """
+    global _status
+    emoji = _status
+    _status = ""
+    return emoji

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -3,6 +3,8 @@ import logging
 import re
 from pathlib import Path
 
+from GENESIS_orchestrator import status_emoji
+
 # Настройка логгера
 logger = logging.getLogger(__name__)
 
@@ -88,9 +90,9 @@ async def send_split_message(bot, chat_id, text, parse_mode=None, **kwargs):
     logger.info(f"Split into {len(parts)} parts")
 
     for i, part in enumerate(parts):
-        # Добавляем эмодзи-индикатор для первой части ответа
-        if i == 0 and not part.startswith("☝🏻"):
-            part = "☝🏻 " + part
+        # Добавляем эмодзи-индикатор и статус для первой части ответа
+        if i == 0:
+            part = f"☝🏻{status_emoji()} " + part.lstrip()
 
         # Добавляем индикатор продолжения/окончания сообщения
         if i < len(parts) - 1:


### PR DESCRIPTION
## Summary
- Expose `update_and_train`, `report_entropy`, and `status_emoji` in GENESIS orchestrator to manage data ingestion and markov entropy
- Hook orchestrator into bot startup and repository watcher, tracking `LAST_MARKOV_ENTROPY` and scaling reply delay
- Prefix bot replies with hourglass emoji during training via updated `send_split_message`

## Testing
- `flake8 GENESIS_orchestrator/__init__.py main.py utils/tools.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab1b02a948329a2f1b5450df05534