### PR TITLE
fix: handle genesis trainer import

### DIFF
--- a/GENESIS_orchestrator/genesis_trainer.py
+++ b/GENESIS_orchestrator/genesis_trainer.py
@@ -18,7 +18,11 @@ except Exception:  # pragma: no cover - fallback when torch missing
     nn = None  # type: ignore
     F = None  # type: ignore
 
-from .orchestrator import model_hyperparams
+try:
+    # When imported as part of the package
+    from .orchestrator import model_hyperparams
+except ImportError:  # pragma: no cover - support running as a script
+    from orchestrator import model_hyperparams  # type: ignore
 
 # ----------------------------------------------------------------------------
 # GPT model definition (adapted from model.py)


### PR DESCRIPTION
## Summary
- handle genesis_trainer import for standalone runs

## Testing
- `flake8 GENESIS_orchestrator/genesis_trainer.py`
- `pytest`
- `python GENESIS_orchestrator/genesis_trainer.py --help`

------
https://chatgpt.com/codex/tasks/task_e_689ab6cee8a48329958b0de8fcddcdf3