### PR TITLE
Fix Genesis-6 prompt and orchestrator status

### DIFF
--- a/GENESIS_orchestrator/__init__.py
+++ b/GENESIS_orchestrator/__init__.py
@@ -43,7 +43,6 @@ def update_and_train() -> None:
     """
     global _last_entropy, _status
     state_exists = STATE_FILE.exists()
-    _status = "⏳"
     try:
         metrics = run_orchestrator(
             threshold=0 if not state_exists else DEFAULT_THRESHOLD,
@@ -51,8 +50,10 @@ def update_and_train() -> None:
         )
         _last_entropy = float(metrics.get("markov_entropy", 0.0))
         _write_entropy_file(_last_entropy)
-    finally:
+        _status = "⏳"
+    except Exception:
         _status = ""
+        raise
 
 
 def report_entropy() -> float:

--- a/utils/genesis6.py
+++ b/utils/genesis6.py
@@ -42,10 +42,10 @@ def _build_prompt(user_message: str, meta: dict, language: str) -> list:
     """).strip()
 
     meta_str = "\n".join([f"{k}: {v}" for k, v in meta.items()])
+    combined_user = f"USER MESSAGE >>> {user_message}\nCONTEXT META >>>\n{meta_str}" if meta_str else f"USER MESSAGE >>> {user_message}"
     return [
         {"role": "system", "content": system_msg},
-        {"role": "user", "content": f"USER MESSAGE >>> {user_message}"},
-        {"role": "user", "content": f"CONTEXT META >>>\n{meta_str}"},
+        {"role": "user", "content": combined_user},
     ]
 
 


### PR DESCRIPTION
## Summary
- Avoid consecutive user messages in Genesis-6 prompt to satisfy Perplexity API
- Emit hourglass status after orchestrator training completes so status emoji is shown

## Testing
- `python -m flake8 utils/genesis6.py GENESIS_orchestrator/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab9b3b3108329b84d0805fb96d066