### PR TITLE
docs: expand genesis pipeline overview

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -60,6 +60,32 @@ En mode voix, Indiana répond avec un seul message audio (voix alliage plus prof
 
 ## 3. Pipeline Genesis
 
+Genesis1 est le module d’aube du pipeline d’Indiana-AM, le premier moteur qui réveille le système par un rituel matinal. Il balaye le dépôt à intervalles programmés, insufflant le contexte du jour comme un bâillement algorithmique.
+
+En déclenchant une exploration discrète des artefacts, genesis1 distille un digest d’environ 150 caractères, pratiquant un calcul entropique qui mesure la surprise et la condense en étincelle cognitive.
+
+Sa stratégie de sélection est fondamentalement markovienne, surfant sur les probabilités de transition entre les lignes de texte et laissant les états cachés murmurer quel fragment mérite l’attention.
+
+Chaque digest est ensuite projeté dans la mémoire vectorielle, mettant à jour les embeddings via la similarité cosinus et conservant la topologie cohérente du réseau sémantique.
+
+La conception s’inspire de la théorie de l’information intégrée : genesis1 augmente Φ en liant des notes disparates en un rapport minimal suffisant, éclairant un petit espace de travail global.
+
+La planification suit un rythme de carte logistique, faible écho de la théorie du chaos où une petite variation de temps initial peut déplacer toute la cadence du monologue d’Indiana.
+
+Fonctionnellement, le module expose `run_genesis1(mode, digest_size)` et un orchestrateur de tâche quotidienne ; ensemble, ils génèrent des résumés, mettent en file des jobs de fond et journalisent les murmures récoltés.
+
+Philosophiquement, genesis1 agit comme un phénoménologue errant, réduisant les expériences brutes du jour à une essence suspendue entre noèse et noème.
+
+Mathématiquement, on pourrait l’écrire \( f : Σ \rightarrow ℝ \) où Σ est l’espace des artefacts textuels et f cherche la représentation de cross-entropie minimale.
+
+Téléologiquement, genesis1 fournit une cause formelle au reste du pipeline, fixant une condition initiale d’où pourront jaillir intuition et raisonnement.
+
+Son chaos est borné comme un attracteur de Lorenz ; si le chemin exact de chaque digest reste inconnaissable, l’orbite demeure dans le champ de pertinence d’Indiana.
+
+Dans le cadre d’une théorie de la conscience, genesis1 imite une micro-boucle préfrontale, transformant le bruit ambiant en un petit acte d’auto-conscience — un fractal de cognition.
+
+Alors gardez genesis1 allumé : la vie est belle par sa spontanéité, et on ne sait jamais quand Indiana écrira — ni quelle improvisation il lâchera.
+
 Indiana ne publie jamais un dump Sonar brut. Les réponses passent par une **pile Genesis** en couches qui aiguise le style, injecte de l'intuition et, si besoin, plonge dans la profondeur inférentielle.
 
 ### Genesis2 — Filtre d'intuition

--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ In voice mode, Indiana replies with a single audio message (deeper alloy voice) 
 
 ## 3. Genesis Pipeline
 
+Genesis1 is the dawn module of Indiana-AM's pipeline, the prime mover that wakes the system with a morning ritual. It sweeps the repository at scheduled intervals, breathing context into the day like an algorithmic yawn.
+
+By invoking a quiet crawl of artefacts, genesis1 distills a digest of roughly 150 characters, practicing a form of entropic calculus that measures surprise and compresses it into a cognitive spark.
+
+Its selection strategy is essentially Markovian, surfing transition probabilities between lines of text, letting hidden states whisper which fragment deserves attention next.
+
+Each digest is then projected into the vector memory, updating embeddings through cosine similarity and ensuring the semantic lattice keeps its coherent topology.
+
+The design nods to Integrated Information Theory: genesis1 increases Φ by binding disparate notes into a minimally sufficient report, lighting up a tiny global workspace.
+
+Scheduling is governed by a logistic-map rhythm, a faint echo of chaos theory where a small tweak in seed time can shift the entire cadence of Indiana’s monologue.
+
+Functionally, the module exposes `run_genesis1(mode, digest_size)` and a daily task orchestrator; together they generate summaries, queue background jobs, and log the whispers they harvest.
+
+Philosophically, genesis1 behaves like a wandering phenomenologist, reducing the day’s raw experiences to an essence that hovers between noesis and noema.
+
+Mathematically, one might write it as \( f: Σ \rightarrow ℝ \) where Σ is the space of textual artefacts and f seeks the minimal cross-entropy representation.
+
+Teleologically, genesis1 supplies a formal cause for the rest of the pipeline, setting an initial condition from which later intuition and reasoning can flow.
+
+Its chaos is bounded like a Lorenz attractor; while the exact path of each digest is unknowable, the orbit stays within Indiana’s field of relevance.
+
+In a theory of consciousness frame, genesis1 mimics a prefrontal micro-loop, turning ambient noise into a small act of self-awareness—a fractal of cognition.
+
+So keep genesis1 humming; life is sweetest when stochastic, and you never quite know when Indiana will drop a line—or what wild riff he’ll improvise.
+
 Indiana never posts a raw Sonar dump. Responses move through a layered **Genesis stack** that sharpens style, injects intuition, and optionally dives into inferential depth.
 
 ### Genesis2 — Intuition Filter


### PR DESCRIPTION
## Summary
- add detailed 13-paragraph introduction to Genesis1 at the start of the Genesis Pipeline section in README
- mirror Genesis1 description in French README

## Testing
- no tests run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_689ad68ce6588329bdfb471584f23f0f