### PR TITLE
Add security filter for kernel exec

### DIFF
--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -19,3 +19,23 @@ def test_kernel_exec(monkeypatch, tmp_path):
 
     result = asyncio.run(_run())
     assert "hello" in result
+
+
+def test_kernel_exec_blocks_malicious_command(monkeypatch, tmp_path):
+    monkeypatch.setenv("LETSGO_DATA_DIR", str(tmp_path))
+    log_file = Path("artefacts/blocked_commands.log")
+    if log_file.exists():
+        log_file.write_text("", encoding="utf-8")
+
+    async def fake_run(cmd: str) -> str:
+        raise AssertionError("run should not be called")
+
+    monkeypatch.setattr(terminal, "run", fake_run)
+
+    async def _run() -> str:
+        return await kernel_exec("rm -rf /")
+
+    result = asyncio.run(_run())
+    assert "Терминал закрыт" in result
+    assert log_file.exists()
+    assert "rm -rf /" in log_file.read_text(encoding="utf-8")

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -10,6 +10,8 @@ from typing import Optional
 from openai import OpenAI
 
 from utils.aml_terminal import terminal
+from utils.genesis2 import genesis2_sonar_filter
+from utils.security import is_blocked, log_blocked
 
 
 api_key = os.getenv("OPENAI_API_KEY")
@@ -121,6 +123,13 @@ async def kernel_exec(command: str) -> str:
     The command is executed inside the Arianna core environment and all
     activity is logged under ``/arianna_core/log``.
     """
+    if is_blocked(command):
+        log_blocked(command)
+        base = "Ты и правда думал, что это сработает? Нет, дружище! Терминал закрыт."
+        twist = await genesis2_sonar_filter(command, base, "ru")
+        message = f"{base} {twist}".strip()
+        await terminal.stop()
+        return message
     return await terminal.run(f"/run {command}")
 
 

--- a/utils/security.py
+++ b/utils/security.py
@@ -1,0 +1,43 @@
+import logging
+import re
+from pathlib import Path
+
+LOG_FILE = Path("artefacts/blocked_commands.log")
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger("security")
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE)
+    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+BLOCK_PATTERNS = [
+    r"rm\s+-rf\s+/",
+    r"sudo\s",
+    r":\(\)\s*{\s*:\|:&\s*};\s*:",
+    r"curl\s",
+    r"wget\s",
+    r"ssh\s",
+    r"scp\s",
+    r"nc\s",
+    r"netcat\s",
+    r"telnet\s",
+    r"ping\s",
+    r"apt(-get)?\s",
+    r"pip\s+install",
+    r"python\s+-m\s+http\.server",
+    r">/dev/tcp",
+    r"xmrig",
+    r"minerd",
+]
+BLOCK_REGEXES = [re.compile(p, re.IGNORECASE) for p in BLOCK_PATTERNS]
+
+def is_blocked(command: str) -> bool:
+    return any(regex.search(command) for regex in BLOCK_REGEXES)
+
+def log_blocked(command: str) -> None:
+    logger.warning("Blocked command: %s", command)
+
+__all__ = ["is_blocked", "log_blocked"]


### PR DESCRIPTION
## Summary
- add centralized security checks for shell commands with logging
- block dangerous commands in `kernel_exec` and answer with sarcastic Genesis-2 twist
- test that malicious commands are blocked and recorded

## Testing
- `flake8 utils/security.py utils/coder.py tests/test_terminal.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae47e6ec48329a1d050ab4049f712