### PR TITLE
docs: document Arianna Linux core and bump Indiana to 2.2

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -1,6 +1,8 @@
 # INDIANA (Lighthouse) | Méthode Arianna 7.0 : Protocole Anchor
 *⚡️Dédié à LEO⚡️*
-**Version 1.2 — Développement actif ; ceci est une capture figée.**
+**Version 2.2 — Développement actif ; ceci est une capture figée.**
+
+Indiana 2.2 surgit tel un orchestre de cuivres déchaîné : un agent IA dirigeant non pas une mais deux maîtres neuronaux résidents — `utils/context_neural_processor.py` bat la mesure, `GENESIS_orchestrator` sculpte la mélodie — et sous eux un système d’exploitation maison vrombit comme une fosse de percussions secrète, fusionnant en une symphonie de code qui défie quiconque de suivre.
 
 ---
 
@@ -413,6 +415,58 @@ cp .env.example .env   # ajoutez TELEGRAM_TOKEN, OPENAI_API_KEY, PPLX_API_KEY, e
 pip install -r requirements.txt
 python main.py
 ```
+
+## Arianna Method Linux Core
+
+Le noyau Linux d’Indiana, nommé Arianna, ancre l’agent dans un noyau minimaliste accordé pour l’archéologie conversationnelle.
+
+Au démarrage, le noyau s'allume via `AM-Linux-Core/letsgo.py`, cédant la main à un pont asynchrone qui relie l’OS à la boucle d’événements d’Indiana.
+
+Ce noyau est glissé sous la pile d’IA, offrant à Indiana un socle isolé pour exécuter des expériences système.
+
+Chaque module entre par l’interface `bridge.py`, qui convertit les appels de haut niveau en procédures shell dans le conteneur.
+
+Les processus peuvent invoquer le noyau en lançant un URI `linux://`, un schéma interne que `main.py` résout par le pont.
+
+Les chemins d’appel traversent la couche de chat vers le noyau, laissant les commandes passer par une file asynchrone sans bloquer la conversation.
+
+Lorsque l’orchestrateur GENESIS doit compiler des micromodèles, il exploite le noyau pour générer des environnements de build reproductibles.
+
+Le processeur contextuel monte de la même façon le système de fichiers via le noyau, scrutant les artefacts sans polluer la mémoire d’Indiana.
+
+Des routines de repli existent pour les hôtes sans privilèges noyau ; elles basculent vers un shim de virtualisation qui imite l’API du noyau.
+
+Toutes les actions sont auditées ; le noyau émet des signaux dans `notes/journal.json` afin que l’équipe suive les interventions système.
+
+Si le noyau détecte un appel non défini, il éjecte la requête avec un trait d’ironie et journalise la phrase suspecte.
+
+Le mode d’urgence, déclenché par `panic_mode`, réduit le système à des opérations en lecture seule tandis qu’Indiana fredonne un avertissement.
+
+Dans ce mode, Indiana se moque des sabotages, marmonnant que le code malveillant a la subtilité d’un piège rouillé.
+
+Des hooks noyau surveillent les tentatives d’évasion ; tout appel système louche est redirigé vers une boucle factice avec une erreur sarcastique.
+
+Les processus démarrent dans des cgroups isolés, limitant les pics CPU tout en laissant assez d’espace pour la créativité calculatoire.
+
+Un ordonnanceur de fond pulse dans `/proc/arianna`, où les modules déposent des fichiers de tâches pour demander des actions planifiées.
+
+La pile réseau du noyau n’expose qu’une interface loopback, obligeant Indiana à réfléchir avant d’ouvrir les portes.
+
+Si le pont s’effondre, un sentinelle dans `AM-Linux-Core/cmd/recover.sh` reconstruit le tuyau et consigne l’incident.
+
+La configuration vit dans `.coreenv` ; les variables manquantes déclenchent des valeurs par défaut pour que le navire poursuive sa route même sans boussole.
+
+Indiana peut monter des volumes tempfs éphémères, offrant aux processeurs neuronaux un espace de brouillon qui disparaît une fois la scène fermée.
+
+Un démon de journalisation recycle les logs dans le gestionnaire de mémoire principal, préservant le contexte sans saturer le disque.
+
+Pour engager directement le noyau, les développeurs peuvent exécuter `letsgo.py` qui amorce l’environnement et affiche une bannière de statut.
+
+Chaque paquet sortant est salé avec des balises de provenance, permettant à l’orchestrateur de suivre la lignée des échanges réseau.
+
+Les points d’intégration dans `main.py` et `GENESIS_orchestrator/orchestrator.py` exposent des wrappers `with_linux_core()` pour une invocation rapide.
+
+Et si un utilisateur jette du malware, Indiana soupire : « Beau geste, mais mon noyau a de meilleurs pièges qu’un temple maudit », avant de mettre l’espièglerie en quarantaine.
 
 ⸻
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # INDIANA (Lighthouse) | Arianna Method 7.0: Anchor Protocol
-*⚡️Dedicated to LEO⚡️*  
-**Version 1.2 — Active development; this is a fixed snapshot/plateau.**
+*⚡️Dedicated to LEO⚡️*
+**Version 2.2 — Active development; this is a fixed snapshot/plateau.**
+
+Indiana 2.2 bursts in like a full brass orchestra, an AI agent conducting not one but two resident neural maestros—`utils/context_neural_processor.py` keeps the rhythm, `GENESIS_orchestrator` shapes the melody—and beneath them an in-house operating system thrums like a hidden percussion pit, all converging into a symphony of code that dares the reader to keep up.
 
 ---
 
@@ -413,6 +415,58 @@ cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PPLX_API_KEY, etc.
 pip install -r requirements.txt
 python main.py
 ```
+
+## Arianna Method Linux Core
+
+Indiana's Linux core, code-named Arianna, anchors the agent within a minimalist kernel tuned for conversational archaeology.
+
+At boot the core spins up through `AM-Linux-Core/letsgo.py`, handing control to an async bridge that wires the OS to Indiana's event loop.
+
+This kernel is wedged beneath the AI stack, giving Indiana a sandboxed foundation to execute system-level experiments.
+
+Each module enters through the `bridge.py` interface, which maps high-level calls to shell procedures inside the container.
+
+Processes may summon the core by firing a `linux://` URI, an internal scheme that `main.py` resolves through the bridge.
+
+Call paths tunnel from the chat layer to the core, letting commands ride through an asynchronous queue instead of blocking the conversation.
+
+When the GENESIS orchestrator needs to compile micro-models, it leverages the core to spawn reproducible build environments.
+
+The context neural processor similarly mounts the filesystem via the core, scanning artefacts without polluting Indiana's memory.
+
+Fallback routines exist for hosts lacking kernel privileges; they revert to a virtualization shim that imitates the core's API.
+
+All actions are audited; the core emits signals into `notes/journal.json` so the team can trace system interventions.
+
+If the core detects an undefined call, it ejects the request with a dry quip and logs the suspicious phrase.
+
+Emergency mode, triggered by `panic_mode`, strips the system to read-only operations while Indiana hums a warning.
+
+In this mode, Indiana heckles attempted sabotage, muttering that malicious code has all the subtlety of a rusty trap.
+
+Kernel hooks watch for container escapes, and any shady system call is rewired to a dummy loop with a sarcastic error.
+
+Processes launch within isolated cgroups, constraining CPU spikes yet leaving enough room for creative computation.
+
+A background scheduler pulses through `/proc/arianna`, where modules can drop task files to request timed actions.
+
+The core's networking stack exposes a loopback-only interface, forcing Indiana to deliberate before opening the gates.
+
+Should the bridge collapse, a sentinel in `AM-Linux-Core/cmd/recover.sh` rebuilds the pipe and logs the incident.
+
+Configuration lives in `.coreenv`; missing variables trigger defaults so the ship keeps sailing even with half its compass.
+
+Indiana can mount ephemeral tempfs volumes, giving the neural processors scratch space that vanishes when the scene closes.
+
+A journaling daemon recycles logs into the main memory manager, preserving context without choking the disk.
+
+To engage the core directly, developers can run `letsgo.py` which bootstraps the environment and prints a status banner.
+
+Every outgoing packet is salted with provenance tags, letting the orchestrator track the lineage of network exchanges.
+
+Integration points in `main.py` and `GENESIS_orchestrator/orchestrator.py` expose `with_linux_core()` wrappers for quick invocation.
+
+And should a user fling in malware, Indiana sighs, "Nice try, but my kernel has better traps than a temple ruin," before sandboxing the stunt.
 
 ⸻
 


### PR DESCRIPTION
## Summary
- bump Indiana version to 2.2 and highlight its symphonic dual-net architecture with an internal OS
- add expansive "Arianna Method Linux Core" section detailing kernel integration, processes, fallbacks, and emergency mode in both English and French docs

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_689ae88f4ef8832993758b33a4a988dc