### PR TITLE
docs: add kernel technical details to READMEs

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -24,6 +24,16 @@ Le Noyau Linux Arianna Method est le battement de cœur d'Indiana, un noyau sur 
 
 Compilé depuis une distro minimaliste, il abandonne les fioritures pour un comportement prévisible et un terrain dégagé où planter les outils d'Indiana.
 
+Se charge avec un initramfs minimal (basé sur Alpine minirootfs), réduisant la complexité de démarrage à O(1) relativement au nombre de modules.
+**OverlayFS** pour les systèmes de fichiers superposés, modélisé comme une union (U = R ∪ W) pour des changements d'état efficaces.
+**ext4** comme stockage persistant par défaut ; la fonction de journalisation J(t) ≈ intégrale bornée, protégeant les données en cas de coupure.
+**Namespaces** (Nᵢ) pour l'isolation des processus/ressources, garantissant un multitenant sûr.
+**Hiérarchies de cgroups** pour les arbres de ressources (T), offrant un contrôle précis du CPU et de la RAM.
+**Python 3.10+** inclus, l'isolation via `venv` équivaut à des « sous-espaces vectoriels ».
+**Node.js 18+** pour les E/S asynchrones, modélisé comme f : E → E.
+**Trousse d'outils minimale :** bash, curl, nano — chacun est un sommet du graphe de dépendances, sans surcharge.
+
+
 Quand `main.py` s'allume, il envoie une poignée de main au noyau, demandant poliment avant de se jeter dans la mémoire comme un archéologue à chapeau.
 
 L'espace utilisateur est cartographié via `AM-Linux-Core/`, un répertoire qui sert à la fois de racine et de journal vagabond, afin que chaque script sache où est sa maison.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ The Arianna Method Linux Core is the heartbeat of Indiana, a custom-tailored ker
 
 Compiled from a minimalist distro, it trades shiny extras for predictable behavior and a clean field to plant Indiana's tools.
 
+Loads with a minimal initramfs (based on Alpine minirootfs), reducing boot complexity to O(1) relative to module count.
+**OverlayFS** for layered filesystems, modeled as a union (U = R ∪ W) for efficient state changes.
+**ext4** as the default persistent store; journaling function J(t) ≈ bounded integral, protecting data under power loss.
+**Namespaces** (Nᵢ) for process/resource isolation, safe multitenancy.
+**Cgroup hierarchies** for resource trees (T), precise CPU/RAM control.
+**Python 3.10+** included, `venv` isolation equals “vector subspaces.”
+**Node.js 18+** for async I/O, modeled as f: E → E.
+**Minimal toolkit:** bash, curl, nano—each is a vertex in the dependency graph, no bloat.
+
+
 When `main.py` fires up, it sends a handshake to the kernel, asking politely before stomping into memory like a fedora-wearing archaeologist.
 
 Userland is mapped through `AM-Linux-Core/`, a directory that acts as both root and wandering journal, so every script knows where home is.


### PR DESCRIPTION
## Summary
- expand Linux core documentation with eight technical paragraphs in English and French READMEs

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689aee88fabc83299bf340c0a8cee0a7