### PR TITLE
Use logging in vector memory initialization

### DIFF
--- a/tests/test_dayandnight.py
+++ b/tests/test_dayandnight.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from pathlib import Path
 
 import pytest
@@ -16,3 +17,19 @@ async def test_store_and_fetch_last_day(monkeypatch):
     await dayandnight._store_last_day("2024-01-01", "hi")
     last = await dayandnight._fetch_last_day()
     assert last == "2024-01-01"
+
+
+@pytest.mark.asyncio
+async def test_init_vector_memory_logs(monkeypatch, caplog):
+    store = LocalVectorStore()
+    monkeypatch.setattr(dayandnight, "vector_store", store)
+
+    with caplog.at_level(logging.INFO):
+        await dayandnight.init_vector_memory()
+    assert "No daily log found in vector memory" in caplog.text
+
+    await dayandnight._store_last_day("2024-01-02", "hi")
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        await dayandnight.init_vector_memory()
+    assert "Last daily log stored on 2024-01-02" in caplog.text

--- a/utils/dayandnight.py
+++ b/utils/dayandnight.py
@@ -9,7 +9,11 @@ from .config import settings
 
 vector_store = create_vector_store(max_size=1000)
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
 
 async def _fetch_last_day():
     """Return the date string of the last daily log if present."""
@@ -69,12 +73,16 @@ async def ensure_daily_entry(reflection_fn=default_reflection):
     return None
 
 async def init_vector_memory():
-    """Check and report the date of the last stored daily entry."""
+    """Check and report the date of the last stored daily entry.
+
+    Logs a message at the INFO level reporting the date of the most recent
+    daily log in the vector store or indicating that none was found.
+    """
     last = await _fetch_last_day()
     if last:
-        print(f"Last daily log stored on {last}")
+        logger.info("Last daily log stored on %s", last)
     else:
-        print("No daily log found in vector memory")
+        logger.info("No daily log found in vector memory")
 
 async def start_daily_task():
     """Background task that ensures a daily entry every 24 hours."""


### PR DESCRIPTION
## Summary
- configure module-level logger in `dayandnight` and replace prints with `logger.info`
- document logging behavior for `init_vector_memory`
- test that `init_vector_memory` writes to log

## Testing
- `flake8 utils/dayandnight.py tests/test_dayandnight.py`
- `pytest tests/test_dayandnight.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0c9361f083299754f49049df1c6b