### PR TITLE
Improve RepoWatcher error logging

### DIFF
--- a/tests/test_repo_monitor.py
+++ b/tests/test_repo_monitor.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure project root is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils.repo_monitor as repo_monitor  # noqa: E402
+from utils.repo_monitor import RepoWatcher  # noqa: E402
+
+
+def test_on_change_error_logs(monkeypatch, tmp_path):
+    (tmp_path / "file.txt").write_text("data", encoding="utf-8")
+
+    def failing_callback():
+        raise RuntimeError("boom")
+
+    watcher = RepoWatcher([tmp_path], failing_callback)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr(repo_monitor, "logger", mock_logger)
+
+    watcher.check_now()
+
+    mock_logger.error.assert_called_once()
+    args, kwargs = mock_logger.error.call_args
+    assert "on_change callback" in args[0]
+    assert kwargs.get("exc_info") is True

--- a/utils/repo_monitor.py
+++ b/utils/repo_monitor.py
@@ -1,8 +1,12 @@
 import time
 import hashlib
 import threading
+import logging
 from pathlib import Path
 from typing import Callable, Dict, Iterable
+
+
+logger = logging.getLogger(__name__)
 
 
 class RepoWatcher:
@@ -47,7 +51,7 @@ class RepoWatcher:
             try:
                 self.on_change()
             except Exception:
-                pass
+                logger.error("Error in on_change callback", exc_info=True)
 
     def _scan(self) -> Dict[Path, str]:
         files: Dict[Path, str] = {}
@@ -67,6 +71,7 @@ class RepoWatcher:
                                 h.update(chunk)
                         files[p] = h.hexdigest()
                     except Exception:
+                        logger.error("Failed hashing file %s", p, exc_info=True)
                         continue
         return files
 
@@ -80,4 +85,4 @@ class RepoWatcher:
                 try:
                     self.on_change()
                 except Exception:
-                    pass
+                    logger.error("Error in on_change callback", exc_info=True)


### PR DESCRIPTION
## Summary
- log errors in RepoWatcher using `logger.error` and include file or stack context
- add regression test verifying errors trigger logging

## Testing
- `python -m flake8 utils/repo_monitor.py tests/test_repo_monitor.py`
- `python -m pytest tests/test_repo_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_689b0cc009108329a49db2abb7b847cf