### PR TITLE
Add exponential backoff for external API calls

### DIFF
--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,55 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import httpx  # noqa: E402
+from utils import genesis3  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+attempts = {"count": 0}
+
+
+class FlakyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, *args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.HTTPError("boom")
+        return DummyResponse({"choices": [{"message": {"content": "<think>x</think>done."}}]})
+
+
+@pytest.mark.asyncio
+async def test_genesis3_retry(monkeypatch):
+    attempts["count"] = 0
+    monkeypatch.setenv("PPLX_API_KEY", "TOKEN")
+    monkeypatch.setattr(genesis3.httpx, "AsyncClient", FlakyClient)
+
+    async def fake_sleep(_):
+        pass
+
+    monkeypatch.setattr(genesis3.asyncio, "sleep", fake_sleep)
+
+    result = await genesis3.genesis3_deep_dive("thought", "prompt")
+    assert result == "🔍 done."
+    assert attempts["count"] == 2

--- a/utils/imagine.py
+++ b/utils/imagine.py
@@ -53,8 +53,7 @@ def imagine(prompt: str, size: str = "1024x1024") -> str:
         except Exception as exc:  # pragma: no cover - network
             if attempt == max_retries - 1:
                 return f"Image generation error: {exc}"
-            time.sleep(2)
+            time.sleep(2 ** attempt)
 
 
 __all__ = ["imagine", "enhance_prompt"]
-


### PR DESCRIPTION
## Summary
- add exponential backoff retries for Sonar API in genesis3 and related utilities
- extend retry logic to Perplexity helpers and image generator
- test retry behaviour on transient HTTP failures

## Testing
- `flake8 utils/genesis3.py utils/genesis2.py utils/deepdiving.py utils/genesis1.py utils/imagine.py tests/test_retry.py && echo OK`
- `pytest tests/test_retry.py`

------
https://chatgpt.com/codex/tasks/task_e_689b0cea14f08329a729550ae2af6b71