### PR TITLE
Replace prints with logging and configure logging format

### DIFF
--- a/GENESIS_orchestrator/symphony.py
+++ b/GENESIS_orchestrator/symphony.py
@@ -229,7 +229,7 @@ def main() -> None:
         out = {"model_perplexity": metrics["model_perplexity"]}
     else:
         out = metrics
-    print(json.dumps(out))
+    LOGGER.info(json.dumps(out))
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -41,7 +41,10 @@ from utils.rate_limiter import RateLimitMiddleware
 from GENESIS_orchestrator import update_and_train, report_entropy
 
 # Настройка логгера
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 load_dotenv()

--- a/utils/complexity.py
+++ b/utils/complexity.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 class ThoughtComplexityLogger:
     """Log complexity scale and entropy for each turn."""
@@ -14,7 +17,7 @@ class ThoughtComplexityLogger:
             "entropy": float(entropy),
         }
         self.logs.append(record)
-        print(
+        logger.info(
             f"LOG@{record['timestamp']} | Complexity: {complexity_scale} | Entropy: {entropy:.3f}"
         )
 

--- a/utils/context_neural_processor.py
+++ b/utils/context_neural_processor.py
@@ -15,6 +15,7 @@ import random
 import re
 import json
 from datetime import datetime
+import logging
 
 try:  # Optional dependency
     from bs4 import BeautifulSoup
@@ -77,6 +78,8 @@ except ImportError:
 
     class RarError(Exception):
         pass
+
+logger = logging.getLogger(__name__)
 
 # Глобальные настройки
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -877,7 +880,7 @@ if __name__ == "__main__":
     async def test():
         if args.path:
             text = await parse_and_store_file(args.path)
-            print(text)
+            logger.info(text)
         if args.snapshot:
             await create_repo_snapshot()
 

--- a/utils/deepdiving.py
+++ b/utils/deepdiving.py
@@ -3,12 +3,15 @@ import os
 import httpx
 import asyncio
 from typing import List, Dict, Optional
+import logging
 
 PPLX_API_URL = "https://api.perplexity.ai/chat/completions"
 PPLX_API_KEY = os.getenv("PPLX_API_KEY")  # Переменная окружения
 DEFAULT_MODEL = "sonar-pro"  # Можно "sonar-reasoning-pro" для академического поиска
 DEFAULT_MAX_TOKENS = 1024
 DEFAULT_TIMEOUT = 40
+
+logger = logging.getLogger(__name__)
 
 def _headers() -> dict:
     return {
@@ -88,10 +91,10 @@ if __name__ == "__main__":
     import sys
     q = " ".join(sys.argv[1:]) or "theory of resonance in ai"
     out = asyncio.run(perplexity_search(q))
-    print("-" * 40)
-    print("🧠 Perplexity Search Result:")
-    print(out["answer"])
-    print("-" * 40)
-    print("🔗 Links:")
+    logger.info("-" * 40)
+    logger.info("🧠 Perplexity Search Result:")
+    logger.info(out["answer"])
+    logger.info("-" * 40)
+    logger.info("🔗 Links:")
     for link in out["sources"]:
-        print("  •", link)
+        logger.info("  • %s", link)

--- a/utils/genesis1.py
+++ b/utils/genesis1.py
@@ -4,6 +4,7 @@ import textwrap
 import datetime
 import httpx
 import asyncio
+import logging
 from .config import settings  # TELEGRAM_TOKEN, PPLX_API_KEY, PINECONE_API_KEY и т.д.
 try:
     from .vector_engine import get_vector_engine  # type: ignore
@@ -16,6 +17,8 @@ except ImportError:  # pragma: no cover
 PPLX_MODEL = "sonar-pro"
 PPLX_API_URL = "https://api.perplexity.ai/chat/completions"
 TIMEOUT = 30
+
+logger = logging.getLogger(__name__)
 
 # ====== хаотический выбор ======
 def _chaotic_pick(strings: list[str]) -> str:
@@ -113,8 +116,8 @@ async def run_genesis1(mode: str = "silent", digest_size: int = 150) -> str | No
 
     # 5. Вывод
     if mode != "silent":
-        print(f"[Genesis-1 Fact]\n{digest}\n")
+        logger.info(f"[Genesis-1 Fact]\n{digest}\n")
     else:
-        print("[Genesis-1] Saved internally.")
+        logger.info("[Genesis-1] Saved internally.")
 
     return digest

--- a/utils/genesis2.py
+++ b/utils/genesis2.py
@@ -4,8 +4,11 @@ import random
 import textwrap
 from datetime import datetime, timezone
 import re
+import logging
 
 from .config import settings  # settings.PPLX_API_KEY должен быть определён
+
+logger = logging.getLogger(__name__)
 
 # Самая универсальная рабочая модель на сегодня:
 PPLX_MODEL = "sonar-pro"
@@ -55,7 +58,10 @@ async def _call_sonar(messages: list) -> str:
                 break
             except httpx.HTTPError as e:
                 if attempt == max_attempts - 1:
-                    print("[Genesis-2] Sonar HTTP error:", getattr(e.response, "text", ""))
+                    logger.error(
+                        "[Genesis-2] Sonar HTTP error: %s",
+                        getattr(e.response, "text", ""),
+                    )
                     raise
                 await asyncio.sleep(2 ** attempt)
         data = resp.json()
@@ -77,7 +83,9 @@ async def genesis2_sonar_filter(user_prompt: str, draft_reply: str, language: st
 
         return twist
     except Exception as e:
-        print(f"[Genesis-2] Sonar fail {e} @ {datetime.now(timezone.utc).isoformat()}")
+        logger.error(
+            f"[Genesis-2] Sonar fail {e} @ {datetime.now(timezone.utc).isoformat()}"
+        )
         return ""
 
 

--- a/utils/genesis6.py
+++ b/utils/genesis6.py
@@ -4,8 +4,11 @@ import textwrap
 from datetime import datetime, timezone
 import re
 import json
+import logging
 
 from .config import settings  # settings.PPLX_API_KEY должен быть определён
+
+logger = logging.getLogger(__name__)
 
 PPLX_MODEL = "sonar-pro"
 PPLX_API_URL = "https://api.perplexity.ai/chat/completions"
@@ -62,7 +65,7 @@ async def _call_sonar(messages: list) -> dict:
         try:
             resp.raise_for_status()
         except Exception:
-            print("[Genesis-6] Sonar HTTP error:", resp.text)
+            logger.error("[Genesis-6] Sonar HTTP error: %s", resp.text)
             raise
         data = resp.json()["choices"][0]["message"]["content"].strip()
         try:
@@ -85,5 +88,7 @@ async def genesis6_profile_filter(user_message: str, meta: dict, language: str) 
         profile["timestamp"] = datetime.now(timezone.utc).isoformat()
         return profile
     except Exception as e:
-        print(f"[Genesis-6] fail {e} @ {datetime.now(timezone.utc).isoformat()}")
+        logger.error(
+            f"[Genesis-6] fail {e} @ {datetime.now(timezone.utc).isoformat()}"
+        )
         return {}

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -141,7 +141,7 @@ class MemoryManager:
             return await self.vectorstore.search(query, top_k, user_id=user_id)
         except Exception as e:
             # log and fall back to empty list
-            print(f"Vector search failed: {e}")
+            logger.error(f"Vector search failed: {e}")
             return []
 
     async def last_response(self, user_id: str) -> str:


### PR DESCRIPTION
## Summary
- replace print statements with structured logging across utilities and CLI
- configure basic logging format in entry point

## Testing
- `flake8` *(fails: whitespace issues)*
- `flake8 utils/complexity.py utils/memory.py utils/genesis6.py utils/context_neural_processor.py utils/genesis2.py utils/genesis1.py utils/deepdiving.py GENESIS_orchestrator/symphony.py AM-Linux-Core/letsgo.py main.py`
- `pytest` *(fails: tests/test_terminal.py::test_kernel_exec)*

------
https://chatgpt.com/codex/tasks/task_e_689b11491a188329bf747ef992595119