### PR TITLE
feat: embed-based local vector store with caching

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -353,7 +353,7 @@ Lorsque des identifiants Pinecone existent, `RemoteVectorStore` utilise le clien
 
 `store` insère ou met à jour des vecteurs dans l'index Pinecone, attachant des métadonnées pour le texte et des identifiants utilisateur optionnels. La routine `search` interroge l'index avec des filtres optionnels et renvoie les textes des \( k \) meilleures correspondances.
 
-En absence de Pinecone, un `LocalVectorStore` conserve des extraits dans un dictionnaire en mémoire. La récupération se dégrade élégamment en calculant un ratio `SequenceMatcher` entre la requête et chaque texte stocké, approximant la similarité cosinus dans un espace purement lexical.
+En absence de Pinecone, un `LocalVectorStore` conserve des extraits dans un dictionnaire en mémoire. Il utilise des embeddings OpenAI (ou un substitut léger) avec similarité cosinus. Les embeddings sont mis en cache pour éviter le recalcul, et la recherche peut être bornée en temps ou en nombre de documents.
 
 `create_vector_store` décide à l'exécution quel backend utiliser et émet un avertissement lors du repli vers l'implémentation locale. Ce pattern factory isole les dépendances externes et simplifie les tests.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ When Pinecone credentials exist, `RemoteVectorStore` employs the `AsyncOpenAI` c
 
 `store` upserts vectors into the Pinecone index, attaching metadata for text and optional user identifiers. The analogous `search` routine queries the index with optional filters, returning the top-\( k \) matches’ text fields.
 
-Absent Pinecone, a `LocalVectorStore` retains snippets in an in-memory dictionary. Retrieval degrades gracefully to computing a `SequenceMatcher` ratio between the query and each stored text, approximating cosine similarity in a purely lexical space.
+Absent Pinecone, a `LocalVectorStore` retains snippets in an in-memory dictionary. Retrieval uses OpenAI embeddings (or a lightweight fallback) with cosine similarity. Embeddings are cached to avoid recomputation, and searches may be bounded by time or by the number of documents examined.
 
 `create_vector_store` decides at runtime which backend to use, emitting a warning when falling back to the local implementation. This factory pattern isolates external dependencies and simplifies testing.
 

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -5,9 +5,11 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from utils.vectorstore import LocalVectorStore  # noqa: E402
+from utils.config import settings  # noqa: E402
 
 
 def test_local_vector_store_eviction():
+    settings.OPENAI_API_KEY = ""
     store = LocalVectorStore(max_size=2)
 
     async def _populate():
@@ -20,3 +22,51 @@ def test_local_vector_store_eviction():
     # Oldest entry should be evicted
     assert "1" not in store._store
     assert list(store._store.keys()) == ["2", "3"]
+
+
+def test_local_vector_store_caching(monkeypatch):
+    settings.OPENAI_API_KEY = ""
+    store = LocalVectorStore()
+    calls = {"count": 0}
+
+    async def fake_generate(text: str):
+        calls["count"] += 1
+        return [ord(c) for c in text]
+
+    monkeypatch.setattr(store, "_generate_embedding", fake_generate)
+
+    async def _run():
+        await store.store("1", "hello")
+        await store.store("2", "hello")
+        await store.search("world")
+        await store.search("world")
+
+    asyncio.run(_run())
+
+    # one for storing "hello", one for first "world" query
+    assert calls["count"] == 2
+
+
+def test_search_max_docs_performance():
+    settings.OPENAI_API_KEY = ""
+    store = LocalVectorStore()
+
+    async def _populate():
+        for i in range(5000):
+            await store.store(str(i), f"text{i}")
+        # warm-up to cache query embedding
+        await store.search("query", top_k=1, max_docs=1)
+
+    asyncio.run(_populate())
+
+    import time
+
+    start = time.perf_counter()
+    asyncio.run(store.search("query", top_k=5))
+    full_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    asyncio.run(store.search("query", top_k=5, max_docs=100))
+    limited_time = time.perf_counter() - start
+
+    assert limited_time < full_time


### PR DESCRIPTION
## Summary
- replace SequenceMatcher with embedding-based cosine similarity in local vector store
- cache embeddings and allow bounding searches by time or document count
- add caching and performance tests; document new local vector store behavior

## Testing
- `flake8 utils/vectorstore.py tests/test_vectorstore.py`
- `pytest tests/test_vectorstore.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b11a59c448329b5584020e7abe7af