### PR TITLE
Add startup checks for critical env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,17 @@
+import importlib
+
+import pytest
+
+import utils.config as config
+
+
+def test_missing_telegram_token(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    with pytest.raises(RuntimeError, match="TELEGRAM_BOT_TOKEN"):
+        importlib.reload(config)
+
+
+def test_missing_openai_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        importlib.reload(config)

--- a/utils/config.py
+++ b/utils/config.py
@@ -16,8 +16,8 @@ def _get_vector_store_max_size() -> int | None:
 
 @dataclass
 class Settings:
-    TELEGRAM_TOKEN: str = os.getenv("TELEGRAM_BOT_TOKEN", "")
-    OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+    TELEGRAM_TOKEN: str | None = os.getenv("TELEGRAM_BOT_TOKEN")
+    OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")
     PINECONE_API_KEY: str = os.getenv("PINECONE_API_KEY", "")
     PINECONE_INDEX: str = os.getenv("PINECONE_INDEX", "indiana")
     PINECONE_ENV: str = os.getenv("PINECONE_ENV", "")
@@ -31,6 +31,17 @@ class Settings:
     RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
     RATE_LIMIT_DELAY: float = float(os.getenv("RATE_LIMIT_DELAY", 0))
     VECTOR_STORE_MAX_SIZE: int | None = _get_vector_store_max_size()
+
+    def __post_init__(self) -> None:
+        required = {
+            "TELEGRAM_BOT_TOKEN": self.TELEGRAM_TOKEN,
+            "OPENAI_API_KEY": self.OPENAI_API_KEY,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise RuntimeError(
+                "Missing required environment variables: " + ", ".join(missing)
+            )
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- validate critical env vars at startup and raise clear error if missing
- add tests ensuring missing vars trigger runtime error

## Testing
- `flake8 utils/config.py tests/test_config_env.py tests/conftest.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b123f6b548329b9bff11d00f34a74