### PR TITLE
Add repo monitor callback test and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -r requirements.txt
+      - name: Lint
+        run: flake8 tests/test_repo_monitor.py
+      - name: Run tests
+        run: pytest tests/test_repo_monitor.py

--- a/tests/test_repo_monitor.py
+++ b/tests/test_repo_monitor.py
@@ -26,3 +26,19 @@ def test_on_change_error_logs(monkeypatch, tmp_path):
     args, kwargs = mock_logger.error.call_args
     assert "on_change callback" in args[0]
     assert kwargs.get("exc_info") is True
+
+
+def test_on_change_called_once(tmp_path):
+    """Callback is triggered exactly once when a file changes."""
+    file = tmp_path / "file.txt"
+    file.write_text("first", encoding="utf-8")
+
+    callback = MagicMock()
+    watcher = RepoWatcher([tmp_path], callback)
+
+    watcher._file_sha = watcher._scan()
+
+    file.write_text("second", encoding="utf-8")
+    watcher.check_now()
+
+    callback.assert_called_once()


### PR DESCRIPTION
## Summary
- add test to ensure RepoWatcher triggers callback once on file change
- set up GitHub Actions workflow to lint and run the RepoWatcher tests

## Testing
- `flake8 tests/test_repo_monitor.py`
- `pytest tests/test_repo_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b15a6de8083299bd64316a2ca629f