### PR TITLE
Add coder /help command formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from utils.genesis6 import genesis6_profile_filter
 from utils.deepdiving import perplexity_search
 from utils.vision import analyze_image
 from utils.imagine import imagine
-from utils.coder import interpret_code
+from utils.coder import interpret_code, format_core_commands
 from utils.complexity import (
     ThoughtComplexityLogger,
     estimate_complexity_and_entropy,
@@ -866,9 +866,12 @@ async def handle_message(m: types.Message):
         # Handle coder mode
         if user_id in CODER_USERS:
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
-                result = await interpret_code(text)
-                if profile:
-                    result = await process_with_assistant(result, "", lang, profile)
+                if text.strip() == "/help":
+                    result = format_core_commands()
+                else:
+                    result = await interpret_code(text)
+                    if profile:
+                        result = await process_with_assistant(result, "", lang, profile)
                 twist = await genesis2_sonar_filter(text, result, lang)
             reply = f"{result}\n\n🜂 Investigative Twist → {twist}"
             await memory.save(user_id, text, reply)

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -2,11 +2,15 @@ import asyncio
 import sys
 from pathlib import Path
 
-
 # Ensure project root is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from utils.coder import ACCESS_DENIED_MESSAGE, IndianaCoder  # noqa: E402
+from utils.coder import (  # noqa: E402
+    ACCESS_DENIED_MESSAGE,
+    IndianaCoder,
+    format_core_commands,
+    CORE_COMMANDS,
+)
 
 
 def test_analyze_denies_outside_repo(tmp_path):
@@ -35,3 +39,9 @@ def test_analyze_allows_repo_file(monkeypatch):
         assert result == "OK"
     finally:
         inside_file.unlink()
+
+
+def test_help_lists_core_commands():
+    """Ensure /help returns entries from CORE_COMMANDS."""
+    help_text = format_core_commands()
+    assert any(cmd in help_text for cmd in CORE_COMMANDS)

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -6,12 +6,19 @@ from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+import sys
 
 from openai import OpenAI
 
 from utils.aml_terminal import terminal
 from utils.genesis2 import genesis2_sonar_filter
 from utils.security import is_blocked, log_blocked
+
+# Import core command definitions from the LetsGo terminal
+CORE_DIR = Path(__file__).resolve().parent.parent / "AM-Linux-Core"
+if str(CORE_DIR) not in sys.path:
+    sys.path.append(str(CORE_DIR))
+from letsgo import CORE_COMMANDS  # type: ignore  # noqa: E402
 
 
 api_key = os.getenv("OPENAI_API_KEY")
@@ -104,6 +111,11 @@ class IndianaCoder:
 CODER_SESSION = IndianaCoder()
 
 
+def format_core_commands() -> str:
+    """Return available core commands with descriptions."""
+    return "\n".join(f"{cmd} - {desc}" for cmd, (_, desc) in CORE_COMMANDS.items())
+
+
 async def interpret_code(prompt: str) -> str:
     """Interpret code or handle follow-up questions with context memory."""
     markers = ["def ", "class ", "import ", "\n"]
@@ -139,4 +151,6 @@ __all__ = [
     "IndianaCoder",
     "DraftResponse",
     "kernel_exec",
+    "format_core_commands",
+    "CORE_COMMANDS",
 ]


### PR DESCRIPTION
## Summary
- import and expose CORE_COMMANDS so coder mode can list commands
- handle `/help` in coder mode to show formatted command list
- test that coder `/help` includes core commands

## Testing
- `flake8 utils/coder.py main.py tests/test_coder.py`
- `pytest tests/test_coder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b19a8a8288329b2c9e1df84ef818f