### PR TITLE
Launch letsgo terminal in constrained cgroup

### DIFF
--- a/AM-Linux-Core/README.md
+++ b/AM-Linux-Core/README.md
@@ -154,6 +154,17 @@ The design keeps dependencies minimal. The script relies only on the Python stan
 
 As the project evolves, the terminal is expected to grow into a pluggable orchestrator capable of spawning subprocesses, managing asynchronous tasks and negotiating resources with the kernel via cgroups.
 
+When invoked through the Python bridge, `letsgo.py` now runs inside its own cgroup. Resource ceilings can be tuned by setting environment variables before launch:
+
+* `LETSGO_CPU_LIMIT` writes directly to `cpu.max` and controls the CPU quota, e.g. `50000 100000` for 50% of one core.
+* `LETSGO_MEMORY_LIMIT` writes to `memory.max` and caps the memory footprint, e.g. `512M`.
+
+```
+LETSGO_CPU_LIMIT="50000 100000" LETSGO_MEMORY_LIMIT=512M python3 main.py
+```
+
+The limits are applied after the subprocess starts; absent variables leave the cgroup unmodified.
+
 ⸻
 
 Architecture


### PR DESCRIPTION
## Summary
- Launch letsgo.py under a dedicated cgroup and apply optional CPU and memory limits from `LETSGO_CPU_LIMIT` and `LETSGO_MEMORY_LIMIT`
- Document the new environment variables and how to tune them
- Test that the terminal writes cgroup settings when limits are provided

## Testing
- `flake8 .` *(fails: whitespace and import warnings in existing files)*
- `black --check utils/aml_terminal.py tests/test_terminal.py` *(fails: would reformat files)*
- `pytest -q` *(fails: test_kernel_exec, vector store and dayandnight tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b1b8cc3288329b4789b9049e03fba