### PR TITLE
Add integration tests for bot commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,6 @@ jobs:
           pip install flake8
           pip install -r requirements.txt
       - name: Lint
-        run: flake8 tests/test_repo_monitor.py
+        run: flake8 tests
       - name: Run tests
-        run: pytest tests/test_repo_monitor.py
+        run: pytest

--- a/tests/test_coder_help_integration.py
+++ b/tests/test_coder_help_integration.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import random
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402
+
+
+class DummyMessage:
+    def __init__(self, text="/help"):
+        self.text = text
+        self.from_user = SimpleNamespace(id=123, language_code="en")
+        self.chat = SimpleNamespace(id=123, type="private")
+        self.voice = None
+        self.photo = []
+        self.answers: list[str] = []
+
+    async def answer(self, text: str):
+        self.answers.append(text)
+
+
+class DummySender:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_coder_help_returns_core_commands(monkeypatch):
+    main.CODER_USERS.clear()
+    m = DummyMessage("/help")
+    main.CODER_USERS.add(str(m.from_user.id))
+
+    monkeypatch.setattr(main, "ChatActionSender", lambda **kwargs: DummySender())
+
+    async def fake_genesis6_report(*a, **k):
+        return {}
+
+    async def fake_genesis2_sonar_filter(*a, **k):
+        return "twist"
+
+    async def fake_send_split_message(*a, **k):
+        m.answers.append(k.get("text", a[-1]))
+
+    monkeypatch.setattr(main, "genesis6_report", fake_genesis6_report)
+    monkeypatch.setattr(main, "genesis2_sonar_filter", fake_genesis2_sonar_filter)
+
+    async def fake_memory_save(*a, **k):
+        return None
+
+    monkeypatch.setattr(main, "memory", SimpleNamespace(save=fake_memory_save))
+    monkeypatch.setattr(main, "save_note", lambda *a, **k: None)
+    monkeypatch.setattr(main, "format_core_commands", lambda: "core help")
+    monkeypatch.setattr(main, "is_rate_limited", lambda *a, **k: False)
+    monkeypatch.setattr(main, "send_split_message", fake_send_split_message)
+    monkeypatch.setattr(random, "random", lambda: 1.0)
+
+    await main.handle_message(m)
+
+    assert m.answers == ["core help\n\n🜂 Investigative Twist → twist"]
+    main.CODER_USERS.clear()

--- a/tests/test_emergency.py
+++ b/tests/test_emergency.py
@@ -32,6 +32,15 @@ async def test_emergency_command_toggles_flag():
 
 
 @pytest.mark.asyncio
+async def test_emergency_command_deactivates():
+    main.EMERGENCY_MODE = True
+    m = DummyMessage("/emergency")
+    await main.toggle_emergency_mode(m)
+    assert main.EMERGENCY_MODE is False
+    assert any("deactivated" in ans.lower() for ans in m.answers)
+
+
+@pytest.mark.asyncio
 async def test_emergency_routes_messages(monkeypatch):
     main.EMERGENCY_MODE = True
 


### PR DESCRIPTION
## Summary
- test coder `/help` handling with mocked Telegram and LetsGo
- expand `/emergency` tests to cover deactivation
- run full test suite and linting in CI

## Testing
- `flake8 tests/test_coder_help_integration.py tests/test_emergency.py`
- `pytest tests/test_coder_help_integration.py tests/test_emergency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1f9ec8608329ad5d294380c03417