### PR TITLE
test: cover coder utilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,6 @@ jobs:
           pip install flake8
           pip install -r requirements.txt
       - name: Lint
-        run: flake8 tests/test_repo_monitor.py
+        run: flake8 tests/test_repo_monitor.py tests/test_coder.py
       - name: Run tests
-        run: pytest tests/test_repo_monitor.py
+        run: pytest tests/test_repo_monitor.py tests/test_coder.py

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -10,6 +10,8 @@ from utils.coder import (  # noqa: E402
     IndianaCoder,
     format_core_commands,
     CORE_COMMANDS,
+    generate_code,
+    kernel_exec,
 )
 
 
@@ -44,4 +46,86 @@ def test_analyze_allows_repo_file(monkeypatch):
 def test_help_lists_core_commands():
     """Ensure /help returns entries from CORE_COMMANDS."""
     help_text = format_core_commands()
+    assert "/help" in help_text
     assert any(cmd in help_text for cmd in CORE_COMMANDS)
+
+
+def test_generate_code_short(monkeypatch):
+    async def fake_ask(self, prompt: str) -> str:
+        return "print('hi')"
+
+    monkeypatch.setattr(IndianaCoder, "_ask", fake_ask)
+    result = asyncio.run(generate_code("say hi"))
+    assert result.text == "print('hi')"
+    assert result.file_content is None
+
+
+def test_generate_code_long(monkeypatch):
+    long_code = "x" * 4000
+
+    async def fake_ask(self, prompt: str) -> str:
+        return long_code
+
+    monkeypatch.setattr(IndianaCoder, "_ask", fake_ask)
+    result = asyncio.run(generate_code("long code"))
+    assert result.text is None
+    assert result.file_content == long_code
+
+
+def test_kernel_exec_blocks(monkeypatch):
+    logs = {}
+
+    class FakeTerminal:
+        def __init__(self):
+            self.ran = False
+            self.stopped = False
+
+        async def run(self, cmd: str):
+            self.ran = True
+            return "ran"  # pragma: no cover - not expected
+
+        async def stop(self):
+            self.stopped = True
+
+    async def fake_filter(command: str, base: str, lang: str) -> str:
+        return "twist"
+
+    fake_term = FakeTerminal()
+    monkeypatch.setattr("utils.coder.terminal", fake_term)
+    monkeypatch.setattr("utils.coder.is_blocked", lambda cmd: True)
+    monkeypatch.setattr("utils.coder.log_blocked", lambda cmd: logs.setdefault("cmd", cmd))
+    monkeypatch.setattr("utils.coder.genesis2_sonar_filter", fake_filter)
+
+    result = asyncio.run(kernel_exec("rm -rf /"))
+    assert "Терминал закрыт" in result
+    assert "twist" in result
+    assert logs["cmd"] == "rm -rf /"
+    assert fake_term.stopped is True
+    assert fake_term.ran is False
+
+
+def test_kernel_exec_runs(monkeypatch):
+    class FakeTerminal:
+        def __init__(self):
+            self.cmd = None
+            self.stopped = False
+
+        async def run(self, cmd: str):
+            self.cmd = cmd
+            return "ok"
+
+        async def stop(self):
+            self.stopped = True
+
+    async def raise_filter(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("genesis2_sonar_filter called")
+
+    fake_term = FakeTerminal()
+    monkeypatch.setattr("utils.coder.terminal", fake_term)
+    monkeypatch.setattr("utils.coder.is_blocked", lambda cmd: False)
+    monkeypatch.setattr("utils.coder.genesis2_sonar_filter", raise_filter)
+
+    result = asyncio.run(kernel_exec("echo hi"))
+    assert result == "ok"
+    assert fake_term.cmd == "/run echo hi"
+    assert fake_term.stopped is False


### PR DESCRIPTION
## Summary
- expand coder tests for /help, code generation limits and command blocking
- run new coder tests in CI alongside repo monitor tests

## Testing
- `flake8 tests/test_repo_monitor.py tests/test_coder.py`
- `pytest tests/test_repo_monitor.py tests/test_coder.py`


------
https://chatgpt.com/codex/tasks/task_e_689b201c836c8329a3d06cf07cf282ab