### PR TITLE
Implement whitelist security with log rotation

### DIFF
--- a/utils/security.py
+++ b/utils/security.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
 LOG_FILE = Path("artefacts/blocked_commands.log")
@@ -7,13 +8,27 @@ LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 logger = logging.getLogger("security")
 if not logger.handlers:
-    handler = logging.FileHandler(LOG_FILE)
-    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    handler = TimedRotatingFileHandler(
+        LOG_FILE, when="midnight", backupCount=7, encoding="utf-8"
+    )
+    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 
-BLOCK_PATTERNS = [
+# Whitelist of allowed commands
+ALLOWED_PATTERNS = [
+    r"^echo\b",
+    r"^ls\b",
+    r"^cat\b",
+    r"^pwd\b",
+    r"^whoami\b",
+    r"^date\b",
+]
+ALLOWED_REGEXES = [re.compile(p, re.IGNORECASE) for p in ALLOWED_PATTERNS]
+
+# Suspicious sequences to warn about
+SUSPICIOUS_PATTERNS = [
     r"rm\s+-rf\s+/",
     r"sudo\s",
     r":\(\)\s*{\s*:\|:&\s*};\s*:",
@@ -32,12 +47,26 @@ BLOCK_PATTERNS = [
     r"xmrig",
     r"minerd",
 ]
-BLOCK_REGEXES = [re.compile(p, re.IGNORECASE) for p in BLOCK_PATTERNS]
+SUSPICIOUS_REGEXES = [re.compile(p, re.IGNORECASE) for p in SUSPICIOUS_PATTERNS]
+
 
 def is_blocked(command: str) -> bool:
-    return any(regex.search(command) for regex in BLOCK_REGEXES)
+    """Return True if command is not in the whitelist.
+
+    Suspicious sequences are logged regardless of allow status.
+    """
+
+    if any(regex.search(command) for regex in SUSPICIOUS_REGEXES):
+        logger.warning("Suspicious command sequence: %s", command)
+
+    allowed = any(regex.search(command) for regex in ALLOWED_REGEXES)
+    return not allowed
+
 
 def log_blocked(command: str) -> None:
-    logger.warning("Blocked command: %s", command)
+    """Log a blocked command attempt."""
+
+    logger.error("Blocked command: %s", command)
+
 
 __all__ = ["is_blocked", "log_blocked"]


### PR DESCRIPTION
## Summary
- Replace blacklist with whitelist of safe commands and warn on suspicious patterns
- Record blocked commands with daily-rotating logs in `artefacts/`
- Extend terminal tests for whitelist behavior and suspicious logging

## Testing
- `flake8 utils/security.py tests/test_terminal.py`
- `pytest tests/test_terminal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b247db1c08329a0f96653eae7d285