### PR TITLE
Add rawthinking commands and adjust deep mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -347,6 +347,8 @@ async def run_deep_dive(chat_id: int, user_id: str, query: str, lang: str) -> No
 async def setup_bot_commands() -> None:
     """Configure bot commands for menu button."""
     commands = [
+        types.BotCommand(command="rawthinking", description="make it raw --"),
+        types.BotCommand(command="rawoff", description="no raw"),
         types.BotCommand(command="deep", description="deep mode"),
         types.BotCommand(command="deepoff", description="deep off"),
         types.BotCommand(command="voiceon", description="voice mode"),
@@ -656,10 +658,21 @@ async def toggle_emergency_mode(m: types.Message):
 async def enable_deep_mode(m: types.Message):
     """Enable persistent Genesis-3 deep dives."""
     global FORCE_DEEP_DIVE
-    FORCE_DEEP_DIVE = True
     user_id = str(m.from_user.id)
     lang = get_user_language(user_id, m.text or "", m.from_user.language_code)
     await genesis6_report(user_id, m.text or "", lang)
+    if user_id in RAW_THINKING_USERS:
+        templates = [
+            "DEEP is incompatible with RAW; choose one path.",
+            "RAW mode blocks DEEP—spirit and concept clash.",
+            "You can't blend RAW with DEEP. Pick a side.",
+            "RAW and DEEP don't mix; it's either this or that.",
+        ]
+        base = random.choice(templates)
+        reply = await genesis2_sonar_filter(m.text or "", base, lang)
+        await m.answer(reply)
+        return
+    FORCE_DEEP_DIVE = True
     await m.answer("☝🏻 deep mode enabled")
 
 
@@ -908,10 +921,14 @@ async def handle_message(m: types.Message):
             responses = await run_rawthinking(text)
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
                 await asyncio.sleep(3)
-            await send_split_message(bot, chat_id=chat_id, text=responses[0])
+            await send_split_message(
+                bot, chat_id=chat_id, text=f"Indiana-B\n{responses[0]}"
+            )
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
                 await asyncio.sleep(5)
-            await send_split_message(bot, chat_id=chat_id, text=responses[1])
+            await send_split_message(
+                bot, chat_id=chat_id, text=f"Indiana-C\n{responses[1]}"
+            )
             placeholder = await m.answer("Indiana sums it up...")
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
                 await asyncio.sleep(2)


### PR DESCRIPTION
## Summary
- Surface `/rawthinking` and `/rawoff` commands in the bot menu for quick toggling
- Block `/deep` when raw thinking is active with genesis2-filtered explanation
- Label raw thinking outputs as Indiana-B and Indiana-C for clarity

## Testing
- `flake8 main.py`
- `pytest` *(fails: AssertionError in AM-Linux-Core/tests/test_letsgo.py::test_status_fields, tests/test_dayandnight.py::test_store_and_fetch_last_day, tests/test_dayandnight.py::test_init_vector_memory_logs, tests/test_memory.py::test_memory_save_and_retrieve, tests/test_memory.py::test_prune_user_records, tests/test_rate_limit.py::test_rate_limiter_stops_responses, tests/test_terminal.py::test_kernel_exec, tests/test_terminal.py::test_kernel_exec_blocks_malicious_command, tests/test_terminal.py::test_kernel_exec_logs_suspicious_sequences, tests/test_terminal.py::test_cgroup_limits)*

------
https://chatgpt.com/codex/tasks/task_e_689c6f1496b8832988ce7b1b2695f51c