### PR TITLE
Refine raw thinking mode and disable coder overlap

### DIFF
--- a/indiana_b.py
+++ b/indiana_b.py
@@ -9,7 +9,6 @@
 
 import os
 import httpx
-import json
 import asyncio
 
 # Badass Indiana Persona: 80% original, 20% cynical shadow-self
@@ -48,16 +47,25 @@ GROK3_HEADERS = {
     "Content-Type": "application/json"
 }
 
-async def badass_indiana_chat(prompt: str) -> str:
-    """Async function to query Grok-3 with badass Indiana persona."""
+async def badass_indiana_chat(prompt: str, lang: str = "en") -> str:
+    """Async function to query Grok-3 with badass Indiana persona.
+
+    The response is always returned in the language specified by ``lang`` and is
+    addressed to the main Indiana agent rather than directly to the user.
+    """
+    system_prompt = (
+        f"{INDIANA_BADASS_PERSONA}\n"
+        f"Respond only in {lang} and address your thoughts to the main Indiana."
+        " Do not speak to the user directly."
+    )
     payload = {
         "model": "grok-3",
         "temperature": 0.8,
         "max_tokens": 1000,
         "messages": [
-            {"role": "system", "content": INDIANA_BADASS_PERSONA},
-            {"role": "user", "content": prompt}
-        ]
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
     }
     async with httpx.AsyncClient(timeout=60) as client:
         resp = await client.post(GROK3_API_URL, headers=GROK3_HEADERS, json=payload)

--- a/tests/test_coder_help_integration.py
+++ b/tests/test_coder_help_integration.py
@@ -65,3 +65,14 @@ async def test_coder_help_returns_core_commands(monkeypatch):
 
     assert m.answers == ["core help\n\n🜂 Investigative Twist → twist"]
     main.CODER_USERS.clear()
+
+
+@pytest.mark.asyncio
+async def test_coder_ignored_during_rawthinking():
+    main.CODER_USERS.clear()
+    main.RAW_THINKING_USERS.add("123")
+    m = DummyMessage("/coder")
+    await main.enable_coder(m)
+    assert m.answers == []
+    assert "123" not in main.CODER_USERS
+    main.RAW_THINKING_USERS.clear()

--- a/utils/rawthinking.py
+++ b/utils/rawthinking.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 from pathlib import Path
 
-from langdetect import detect
 from openai import AsyncOpenAI
 
 from utils.config import settings
@@ -19,39 +18,39 @@ client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY
 LOG_FILE = Path("/arianna_core/log/rawthinking.log")
 
 
-async def run_rawthinking(prompt: str) -> list[str]:
-    """Run Indiana-B, Indiana-C, and synthesize a final answer.
+async def run_rawthinking(prompt: str, lang: str) -> str:
+    """Run Indiana-B, Indiana-C, and synthesise a final answer.
 
-    Returns list of [B response, C response, final filtered response].
+    Even if one of the sub-agents fails, a final answer is produced from the
+    available responses without exposing errors to the caller.
     """
-    b_resp = c_resp = final_resp = "— no connection —"
+    b_resp = c_resp = None
 
-    b_task = asyncio.create_task(badass_indiana_chat(prompt))
-    c_task = asyncio.create_task(light_indiana_chat(prompt))
+    b_task = asyncio.create_task(badass_indiana_chat(prompt, lang))
+    c_task = asyncio.create_task(light_indiana_chat(prompt, lang))
 
     try:
         b_resp = await b_task
     except Exception as e:
         logger.error("Indiana-B failed: %s", e)
-        b_resp = "— no connection —"
 
     try:
         c_resp = await c_task
     except Exception as e:
         logger.error("Indiana-C failed: %s", e)
         try:
-            c_resp = await light_indiana_chat_openrouter(prompt)
+            c_resp = await light_indiana_chat_openrouter(prompt, lang)
         except Exception as e2:
             logger.error("Indiana-C fallback failed: %s", e2)
-            c_resp = "— no connection —"
 
-    final_prompt = (
-        f"User asked: {prompt}\n"
-        f"Indiana-B replied: {b_resp}\n"
-        f"Indiana-C replied: {c_resp}\n"
-        "Provide a concise, thoughtful synthesis addressing the user's request."
-    )
+    final_prompt = f"User asked: {prompt}\n"
+    if b_resp:
+        final_prompt += f"Indiana-B replied: {b_resp}\n"
+    if c_resp:
+        final_prompt += f"Indiana-C replied: {c_resp}\n"
+    final_prompt += "Provide a concise, thoughtful synthesis addressing the user's request."
 
+    final_resp = "— no connection —"
     if client:
         try:
             completion = await client.chat.completions.create(
@@ -68,14 +67,6 @@ async def run_rawthinking(prompt: str) -> list[str]:
             final_resp = completion.choices[0].message.content.strip()
         except Exception as e:
             logger.error("Final synthesis failed: %s", e)
-            final_resp = "— no connection —"
-    else:
-        final_resp = "— no connection —"
-
-    try:
-        lang = detect(prompt)
-    except Exception:
-        lang = "en"
 
     try:
         final_resp = await genesis2_sonar_filter(prompt, final_resp, lang)
@@ -86,9 +77,9 @@ async def run_rawthinking(prompt: str) -> list[str]:
         LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         with LOG_FILE.open("a", encoding="utf-8") as f:
             f.write(
-                f"Q: {prompt}\nB: {b_resp}\nC: {c_resp}\nFinal: {final_resp}\n---\n"
+                f"Q: {prompt}\nB: {b_resp or '—'}\nC: {c_resp or '—'}\nFinal: {final_resp}\n---\n",
             )
     except Exception as e:
         logger.error("Failed to log rawthinking: %s", e)
 
-    return [b_resp, c_resp, final_resp]
+    return final_resp


### PR DESCRIPTION
## Summary
- Prevent `/coder` mode when `/rawthinking` is active and ignore `/coder` commands in that state
- Rework raw thinking flow: summarize user question, consult Indiana-B and -C internally, then synthesize final answer
- Ensure sub-agents reply in user language and hide errors if one agent fails; added regression test

## Testing
- `flake8 indiana_b.py indiana_c.py main.py utils/rawthinking.py tests/test_coder_help_integration.py`
- `pytest` *(fails: test_status_fields)*
- `pytest tests/test_coder_help_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c78fa356883299ffa62717cd34b02