### PR TITLE
Expose Indiana-B and Indiana-C reasoning in /rawthinking mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -933,7 +933,15 @@ async def handle_message(m: types.Message):
             )
             await m.answer(f"{summary}\n\n{call_text}")
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
-                final = await run_rawthinking(text, lang)
+                final, b_resp, c_resp = await run_rawthinking(text, lang)
+            if b_resp:
+                await send_split_message(
+                    bot, chat_id=chat_id, text=f"Indiana-B → {b_resp}"
+                )
+            if c_resp:
+                await send_split_message(
+                    bot, chat_id=chat_id, text=f"Indiana-C → {c_resp}"
+                )
             await send_split_message(bot, chat_id=chat_id, text=final)
             await memory.save(user_id, text, final)
             save_note(

--- a/tests/test_rawthinking_mode.py
+++ b/tests/test_rawthinking_mode.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402
+
+
+class DummyMessage:
+    def __init__(self, text="/help"):
+        self.text = text
+        self.from_user = SimpleNamespace(id=123, language_code="en")
+        self.chat = SimpleNamespace(id=123, type="private")
+        self.voice = None
+        self.photo = []
+        self.answers: list[str] = []
+
+    async def answer(self, text: str):
+        self.answers.append(text)
+
+
+class DummySender:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_rawthinking_chain(monkeypatch):
+    main.RAW_THINKING_USERS.add("123")
+    m = DummyMessage("What is life?")
+
+    monkeypatch.setattr(main, "ChatActionSender", lambda **kwargs: DummySender())
+
+    async def fake_genesis6_report(*a, **k):
+        return {}
+
+    async def fake_run_rawthinking(prompt, lang):
+        return ("final answer", "B thoughts", "C thoughts")
+
+    async def fake_memory_save(*a, **k):
+        return None
+
+    async def fake_process_with_assistant(*a, **k):
+        return "summary"
+
+    async def fake_send_split_message(*a, **k):
+        m.answers.append(k.get("text", a[-1]))
+
+    monkeypatch.setattr(main, "genesis6_report", fake_genesis6_report)
+    monkeypatch.setattr(main, "run_rawthinking", fake_run_rawthinking)
+    monkeypatch.setattr(main, "memory", SimpleNamespace(save=fake_memory_save))
+    monkeypatch.setattr(main, "save_note", lambda *a, **k: None)
+    monkeypatch.setattr(main, "process_with_assistant", fake_process_with_assistant)
+    monkeypatch.setattr(main, "send_split_message", fake_send_split_message)
+    monkeypatch.setattr(main, "is_rate_limited", lambda *a, **k: False)
+
+    await main.handle_message(m)
+
+    assert m.answers == [
+        "summary\n\nIndiana-B and Indiana-C, what do you think?",
+        "Indiana-B → B thoughts",
+        "Indiana-C → C thoughts",
+        "final answer",
+    ]
+    main.RAW_THINKING_USERS.clear()

--- a/utils/rawthinking.py
+++ b/utils/rawthinking.py
@@ -18,11 +18,14 @@ client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY
 LOG_FILE = Path("/arianna_core/log/rawthinking.log")
 
 
-async def run_rawthinking(prompt: str, lang: str) -> str:
+async def run_rawthinking(prompt: str, lang: str) -> tuple[str, str | None, str | None]:
     """Run Indiana-B, Indiana-C, and synthesise a final answer.
 
-    Even if one of the sub-agents fails, a final answer is produced from the
-    available responses without exposing errors to the caller.
+    Returns a tuple ``(final, b_resp, c_resp)`` where ``final`` is the main
+    Indiana's reply (already passed through ``genesis2_sonar_filter``) and the
+    other elements contain raw responses from Indiana-B and Indiana-C. Even if
+    one of the sub-agents fails, a final answer is produced from the available
+    responses without exposing errors to the caller.
     """
     b_resp = c_resp = None
 
@@ -82,4 +85,4 @@ async def run_rawthinking(prompt: str, lang: str) -> str:
     except Exception as e:
         logger.error("Failed to log rawthinking: %s", e)
 
-    return final_resp
+    return final_resp, b_resp, c_resp


### PR DESCRIPTION
## Summary
- show Indiana-B and Indiana-C replies during `/rawthinking` sessions
- include sub-agent outputs in `run_rawthinking` so callers can display full chain
- add regression test for rawthinking dialogue flow

## Testing
- `flake8 utils/rawthinking.py main.py tests/test_rawthinking_mode.py`
- `pytest tests/test_rawthinking_mode.py tests/test_coder_help_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8fba02608329a824e59238dcae85