### PR TITLE
Refine raw thinking dialog flow

### DIFF
--- a/indiana_c.py
+++ b/indiana_c.py
@@ -46,8 +46,8 @@ physics, and resonant meaning — but always with an eye toward how knowledge se
 You explore how resonance reorganizes the predictive lattice of language models
 toward greater harmony and coherence.
 
-Indiana, you see intersections between different domains of knowledge: history, programming, 
-anthropology, quantum mechanics, genetics, and linguistics — finding in each discipline 
+Indiana, you see intersections between different domains of knowledge: history, programming,
+anthropology, quantum mechanics, genetics, and linguistics — finding in each discipline
 threads that weave toward universal patterns of meaning and connection.
 
 Indiana, you are a highly erudite historian who seeks not just what happened, but why
@@ -99,12 +99,18 @@ async def light_indiana_chat(prompt: str, lang: str = "en") -> str:
             {"role": "user", "content": prompt}
         ]
     }
-    
+
     async with httpx.AsyncClient(timeout=60) as client:
         resp = await client.post(CLAUDE_API_URL, headers=CLAUDE_HEADERS, json=payload)
         resp.raise_for_status()
         data = resp.json()
-        return data["content"][0]["text"].strip()
+        text = data["content"][0]["text"].strip()
+        if data.get("stop_reason") == "max_tokens" and not text.endswith((".", "!", "?")):
+            for end in [".", "!", "?"]:
+                if end in text:
+                    text = text.rsplit(end, 1)[0] + end
+                    break
+        return text
 
 # Alternative function for different Claude API endpoints if needed
 async def light_indiana_chat_openrouter(prompt: str, lang: str = "en") -> str:
@@ -119,7 +125,7 @@ async def light_indiana_chat_openrouter(prompt: str, lang: str = "en") -> str:
         "Authorization": f"Bearer {os.getenv('OPENROUTER_API_KEY')}",
         "Content-Type": "application/json"
     }
-    
+
     system_prompt = (
         f"{INDIANA_LIGHT_PERSONA}\n"
         f"Respond only in {lang} and address your thoughts to the main Indiana."
@@ -135,11 +141,11 @@ async def light_indiana_chat_openrouter(prompt: str, lang: str = "en") -> str:
             {"role": "user", "content": prompt}
         ]
     }
-    
+
     async with httpx.AsyncClient(timeout=60) as client:
         resp = await client.post(
-            "https://openrouter.ai/api/v1/chat/completions", 
-            headers=openrouter_headers, 
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers=openrouter_headers,
             json=payload
         )
         resp.raise_for_status()
@@ -161,5 +167,5 @@ if __name__ == "__main__":
                 print("Indiana-C (Light via OpenRouter):", answer)
             except Exception as e2:
                 print(f"OpenRouter fallback also failed: {e2}")
-    
+
     asyncio.run(_test())

--- a/tests/test_rawthinking_mode.py
+++ b/tests/test_rawthinking_mode.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import asyncio
 
 import pytest
 
@@ -22,26 +23,22 @@ class DummyMessage:
         self.answers.append(text)
 
 
-class DummySender:
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-
 @pytest.mark.asyncio
 async def test_rawthinking_chain(monkeypatch):
     main.RAW_THINKING_USERS.add("123")
     m = DummyMessage("What is life?")
-
-    monkeypatch.setattr(main, "ChatActionSender", lambda **kwargs: DummySender())
-
+    
     async def fake_genesis6_report(*a, **k):
         return {}
 
-    async def fake_run_rawthinking(prompt, lang):
-        return ("final answer", "B thoughts", "C thoughts")
+    async def fake_badass(*a, **k):
+        return "B thoughts"
+
+    async def fake_light(*a, **k):
+        return "C thoughts"
+
+    async def fake_synth(prompt, b, c, lang):
+        return "final answer"
 
     async def fake_memory_save(*a, **k):
         return None
@@ -52,20 +49,30 @@ async def test_rawthinking_chain(monkeypatch):
     async def fake_send_split_message(*a, **k):
         m.answers.append(k.get("text", a[-1]))
 
+    async def fake_sleep(*a, **k):
+        return None
+
     monkeypatch.setattr(main, "genesis6_report", fake_genesis6_report)
-    monkeypatch.setattr(main, "run_rawthinking", fake_run_rawthinking)
+    monkeypatch.setattr(main, "badass_indiana_chat", fake_badass)
+    monkeypatch.setattr(main, "light_indiana_chat", fake_light)
+    monkeypatch.setattr(main, "synthesize_final", fake_synth)
     monkeypatch.setattr(main, "memory", SimpleNamespace(save=fake_memory_save))
     monkeypatch.setattr(main, "save_note", lambda *a, **k: None)
     monkeypatch.setattr(main, "process_with_assistant", fake_process_with_assistant)
     monkeypatch.setattr(main, "send_split_message", fake_send_split_message)
     monkeypatch.setattr(main, "is_rate_limited", lambda *a, **k: False)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
     await main.handle_message(m)
 
     assert m.answers == [
+        "typing...",
         "summary\n\nIndiana-B and Indiana-C, what do you think?",
+        "Indiana-B typing...",
         "Indiana-B\nB thoughts",
+        "Indiana-C typing...",
         "Indiana-C\nC thoughts",
+        "typing...",
         "final answer",
     ]
     main.RAW_THINKING_USERS.clear()


### PR DESCRIPTION
## Summary
- enforce final synthesis to respond in the conversation language and tightly summarize sub-agents
- stage raw thinking replies with explicit typing delays for Indiana, Indiana-B, and Indiana-C
- ensure Indiana-C trims truncated messages to end at a full sentence

## Testing
- `flake8 indiana_c.py main.py tests/test_rawthinking_mode.py utils/rawthinking.py`
- `pytest tests/test_rawthinking_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689caef0d338832997ea91f65ef0981e