### PR TITLE
Expand rawthinking with new agents

### DIFF
--- a/indiana_b.py
+++ b/indiana_b.py
@@ -56,13 +56,13 @@ async def badass_indiana_chat(prompt: str, lang: str = "en") -> str:
     system_prompt = (
         f"{INDIANA_BADASS_PERSONA}\n"
         f"Respond only in {lang} and address your thoughts to the main Indiana."
-        " Do not speak to the user directly. Keep your answer concise,"\
-        " within roughly 400 tokens."
+        " Do not speak to the user directly. Keep your answer concise,"
+        " within roughly 200 tokens."
     )
     payload = {
         "model": "grok-3",
         "temperature": 0.8,
-        "max_tokens": 400,
+        "max_tokens": 200,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt},
@@ -72,7 +72,13 @@ async def badass_indiana_chat(prompt: str, lang: str = "en") -> str:
         resp = await client.post(GROK3_API_URL, headers=GROK3_HEADERS, json=payload)
         resp.raise_for_status()
         data = resp.json()
-        return data["choices"][0]["message"]["content"].strip()
+        text = data["choices"][0]["message"]["content"].strip()
+        if data["choices"][0].get("finish_reason") == "length" and not text.endswith((".", "!", "?")):
+            for end in [".", "!", "?"]:
+                if end in text:
+                    text = text.rsplit(end, 1)[0] + end
+                    break
+        return text
 
 # Quick test
 if __name__ == "__main__":

--- a/indiana_c.py
+++ b/indiana_c.py
@@ -88,11 +88,11 @@ async def light_indiana_chat(prompt: str, lang: str = "en") -> str:
         f"{INDIANA_LIGHT_PERSONA}\n"
         f"Respond only in {lang} and address your thoughts to the main Indiana."
         " Do not speak to the user directly. Keep your answer concise,"
-        " within roughly 400 tokens."
+        " within roughly 200 tokens."
     )
     payload = {
         "model": "claude-3-5-sonnet-20241022",  # Using latest Claude model
-        "max_tokens": 400,
+        "max_tokens": 200,
         "temperature": 0.7,  # Slightly lower for more thoughtful responses
         "system": system_prompt,
         "messages": [
@@ -130,12 +130,12 @@ async def light_indiana_chat_openrouter(prompt: str, lang: str = "en") -> str:
         f"{INDIANA_LIGHT_PERSONA}\n"
         f"Respond only in {lang} and address your thoughts to the main Indiana."
         " Do not speak to the user directly. Keep your answer concise,"
-        " within roughly 400 tokens."
+        " within roughly 200 tokens."
     )
     payload = {
         "model": "anthropic/claude-3.5-sonnet",
         "temperature": 0.7,
-        "max_tokens": 400,
+        "max_tokens": 200,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt}

--- a/indiana_d.py
+++ b/indiana_d.py
@@ -1,4 +1,4 @@
-# indiana-d.py
+# indiana_d.py
 # Techno-shaman Indiana Utility: DeepSeek Twin Persona for DeepSeek Engine
 # Co-authored by Oleg & Perplexity, Arianna Method 7.0
 
@@ -47,9 +47,11 @@ DEEPSEEK_HEADERS = {
 
 async def techno_indiana_chat(prompt: str, lang: str = "en") -> str:
     """Returns DeepSeek-Indiana's high-voltage techno-shaman answer."""
-    system_prompt = (DEEPSEEK_INDIANA_PERSONA +
-                     f"\nRespond only in {lang}. Address your answer to the main Indiana. "
-                     "Keep your answer terse, ~300 tokens. DO NOT speak directly to user; only as internal field commentary.")
+    system_prompt = (
+        DEEPSEEK_INDIANA_PERSONA
+        + f"\nRespond only in {lang}. Address your answer to the main Indiana. "
+        "Keep your answer terse, ~240 tokens. DO NOT speak directly to user; only as internal field commentary."
+    )
 
     payload = {
         "model": "deepseek-chat",
@@ -58,7 +60,7 @@ async def techno_indiana_chat(prompt: str, lang: str = "en") -> str:
             {"role": "user", "content": prompt}
         ],
         "temperature": 0.93,
-        "max_tokens": 360,  # 300-400 tok, наравне прочими Twin'ами
+        "max_tokens": 240,
     }
 
     async with httpx.AsyncClient(timeout=90) as client:
@@ -67,6 +69,11 @@ async def techno_indiana_chat(prompt: str, lang: str = "en") -> str:
             resp.raise_for_status()
             data = resp.json()
             text = data["choices"][0]["message"]["content"].strip()
+            if data["choices"][0].get("finish_reason") == "length" and not text.endswith((".", "!", "?")):
+                for end in [".", "!", "?"]:
+                    if end in text:
+                        text = text.rsplit(end, 1)[0] + end
+                        break
             # Финальный “техно-марк” (опционально)
             tech_mark = "\n\n// This is not an answer. This is a fracture mark."
             if not text.endswith((".", "!", "…", "...", "—")):

--- a/indiana_g.py
+++ b/indiana_g.py
@@ -1,4 +1,4 @@
-# indiana-g.py
+# indiana_g.py
 # Gravity-Twin Indiana Utility: Female-Archetype Twin Persona for Gemini Engine
 # Co-authored by Oleg & Gemini, resonant in Arianna Method 7.0
 # This module defines the gravity-twin Indiana persona (60% original, 40% vulnerable-contemplative)
@@ -75,7 +75,7 @@ async def gravity_indiana_chat(prompt: str, lang: str = "en") -> str:
         f"{INDIANA_GRAVITY_PERSONA}\n"
         f"Respond only in {lang} and address your thoughts to the main Indiana."
         " Do not speak to the user directly. Keep your answer concise,"
-        " within roughly 400 tokens."
+        " within roughly 200 tokens."
     )
     
     payload = {
@@ -86,8 +86,8 @@ async def gravity_indiana_chat(prompt: str, lang: str = "en") -> str:
             }
         ],
         "generationConfig": {
-            "temperature": 0.9, # Slightly higher for more creative, contemplative responses
-            "maxOutputTokens": 400
+            "temperature": 0.9,  # Slightly higher for more creative, contemplative responses
+            "maxOutputTokens": 200
         }
     }
 
@@ -96,12 +96,11 @@ async def gravity_indiana_chat(prompt: str, lang: str = "en") -> str:
         resp.raise_for_status()
         data = resp.json()
         text = data["candidates"][0]["content"]["parts"][0]["text"].strip()
-        
-        # Check for truncation and append ellipsis if necessary for narrative coherence
-        if data.get("prompt_feedback", {}).get("block_reason") is None and len(text) >= 400 * 3: # 3 characters per token approx
-            if not text.endswith((".", "!", "?")):
-                text += "..."
-        
+        if data.get("prompt_feedback", {}).get("block_reason") is None and not text.endswith((".", "!", "?")):
+            for end in [".", "!", "?"]:
+                if end in text:
+                    text = text.rsplit(end, 1)[0] + end
+                    break
         return text
 
 # Quick test

--- a/tests/test_rawthinking_mode.py
+++ b/tests/test_rawthinking_mode.py
@@ -42,7 +42,13 @@ async def test_rawthinking_chain(monkeypatch):
     async def fake_light(*a, **k):
         return "C thoughts"
 
-    async def fake_synth(prompt, b, c, lang):
+    async def fake_techno(*a, **k):
+        return "D thoughts"
+
+    async def fake_gravity(*a, **k):
+        return "G thoughts"
+
+    async def fake_synth(prompt, b, c, d, g, lang):
         return "final answer"
 
     async def fake_assemble(prompt, draft, lang):
@@ -63,6 +69,8 @@ async def test_rawthinking_chain(monkeypatch):
     monkeypatch.setattr(main, "genesis6_report", fake_genesis6_report)
     monkeypatch.setattr(main, "badass_indiana_chat", fake_badass)
     monkeypatch.setattr(main, "light_indiana_chat", fake_light)
+    monkeypatch.setattr(main, "techno_indiana_chat", fake_techno)
+    monkeypatch.setattr(main, "gravity_indiana_chat", fake_gravity)
     monkeypatch.setattr(main, "synthesize_final", fake_synth)
     monkeypatch.setattr(main, "assemble_final_reply", fake_assemble)
     monkeypatch.setattr(main, "memory", SimpleNamespace(save=fake_memory_save))
@@ -83,13 +91,16 @@ async def test_rawthinking_chain(monkeypatch):
             return False
 
     monkeypatch.setattr(main, "ChatActionSender", DummyChatActionSender)
+    monkeypatch.setattr(main.random, "choice", lambda seq: seq[0])
 
     await main.handle_message(m)
 
     assert m.answers == [
-        "summary\n\nIndiana-B and Indiana-C, what do you think?",
+        "summary\n\nWhat do you think?",
         "Indiana-B\nB thoughts",
         "Indiana-C\nC thoughts",
+        "Indiana-D\nD thoughts",
+        "Indiana-G\nG thoughts",
         "final answer",
     ]
     main.RAW_THINKING_USERS.clear()


### PR DESCRIPTION
## Summary
- Halve Indiana-B and Indiana-C token limits for concise replies
- Add Indiana-D (DeepSeek) and Indiana-G (Gemini) agents with unified messaging and longer limit for D
- Extend rawthinking workflow and tests to orchestrate four Indiana agents sequentially

## Testing
- `python -m flake8 indiana_b.py indiana_c.py indiana_d.py indiana_g.py main.py utils/rawthinking.py tests/test_rawthinking_mode.py`
- `pytest` *(fails: AssertionError, RuntimeError and other errors)*
- `pytest tests/test_rawthinking_mode.py`

------
https://chatgpt.com/codex/tasks/task_e_689ced762cf083298e5219d7654bad9b