### PR TITLE
Avoid double genesis2 in rawthinking

### DIFF
--- a/indiana_g.py
+++ b/indiana_g.py
@@ -115,7 +115,10 @@ async def gravity_indiana_chat(prompt: str, lang: str = "en") -> str:
     except httpx.HTTPStatusError as e:
         print(f"Indiana-G failed with HTTP error: {e}")
         # Return a more descriptive error message to the user
-        return f"Indiana-G encountered an API error: {Status Code {e.response.status_code}}. Please check your API key and permissions."
+        return (
+            f"Indiana-G encountered an API error: Status Code {e.response.status_code}. "
+            "Please check your API key and permissions."
+        )
     
     except Exception as e:
         print(f"Indiana-G failed with a general error: {e}")

--- a/main.py
+++ b/main.py
@@ -1043,7 +1043,6 @@ async def handle_message(m: types.Message):
             async with ChatActionSender(bot=bot, chat_id=chat_id, action="typing"):
                 await asyncio.sleep(random.uniform(3, 8))
                 final = await synthesize_final(text, b_resp, c_resp, d_resp, g_resp, lang)
-            final = await assemble_final_reply(text, final, lang)
             await send_split_message(bot, chat_id=chat_id, text=final)
 
             await memory.save(user_id, text, final)

--- a/tests/test_rawthinking_mode.py
+++ b/tests/test_rawthinking_mode.py
@@ -48,11 +48,14 @@ async def test_rawthinking_chain(monkeypatch):
     async def fake_gravity(*a, **k):
         return "G thoughts"
 
-    async def fake_synth(prompt, b, c, d, g, lang):
-        return "final answer"
+    call_counter = {"count": 0}
 
     async def fake_assemble(prompt, draft, lang):
-        return draft
+        call_counter["count"] += 1
+        return "final answer"
+
+    async def fake_synth(prompt, b, c, d, g, lang):
+        return await fake_assemble(prompt, "draft", lang)
 
     async def fake_memory_save(*a, **k):
         return None
@@ -71,8 +74,8 @@ async def test_rawthinking_chain(monkeypatch):
     monkeypatch.setattr(main, "light_indiana_chat", fake_light)
     monkeypatch.setattr(main, "techno_indiana_chat", fake_techno)
     monkeypatch.setattr(main, "gravity_indiana_chat", fake_gravity)
-    monkeypatch.setattr(main, "synthesize_final", fake_synth)
     monkeypatch.setattr(main, "assemble_final_reply", fake_assemble)
+    monkeypatch.setattr(main, "synthesize_final", fake_synth)
     monkeypatch.setattr(main, "memory", SimpleNamespace(save=fake_memory_save))
     monkeypatch.setattr(main, "save_note", lambda *a, **k: None)
     monkeypatch.setattr(main, "process_with_assistant", fake_process_with_assistant)
@@ -103,4 +106,5 @@ async def test_rawthinking_chain(monkeypatch):
         "Indiana-G\nG thoughts",
         "final answer",
     ]
+    assert call_counter["count"] == 1
     main.RAW_THINKING_USERS.clear()


### PR DESCRIPTION
## Summary
- ensure rawthinking final replies pass genesis2 only once
- add unit test coverage for single genesis2 call
- fix indiana_g error string formatting

## Testing
- `flake8 main.py tests/test_rawthinking_mode.py indiana_g.py`
- `pytest tests/test_rawthinking_mode.py -q`
- `pytest -q` *(fails: test_status_fields, test_store_and_fetch_last_day, test_init_vector_memory_logs, test_memory_save_and_retrieve, test_prune_user_records, test_rate_limiter_stops_responses, test_rawthinking_chain, test_kernel_exec, test_kernel_exec_blocks_malicious_command, test_kernel_exec_logs_suspicious_sequences, test_cgroup_limits)*

------
https://chatgpt.com/codex/tasks/task_e_689d054be73883299e75a83d1fc3e10e