### PR TITLE
Fix invalid f-string in Indiana-G API error handler

### DIFF
--- a/indiana_g.py
+++ b/indiana_g.py
@@ -115,7 +115,10 @@ async def gravity_indiana_chat(prompt: str, lang: str = "en") -> str:
     except httpx.HTTPStatusError as e:
         print(f"Indiana-G failed with HTTP error: {e}")
         # Return a more descriptive error message to the user
-        return f"Indiana-G encountered an API error: {Status Code {e.response.status_code}}. Please check your API key and permissions."
+        return (
+            f"Indiana-G encountered an API error: Status Code {e.response.status_code}. "
+            "Please check your API key and permissions."
+        )
     
     except Exception as e:
         print(f"Indiana-G failed with a general error: {e}")


### PR DESCRIPTION
## Summary
- fix malformed f-string when reporting Gemini API HTTP errors

## Testing
- `flake8 indiana_g.py`
- `pytest` *(fails: AssertionError, RuntimeError, etc. – see log)*

------
https://chatgpt.com/codex/tasks/task_e_689d06f402088329b067c45ef9ae9135