### PR TITLE
Remove Genesis silent mode and commands

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -136,7 +136,7 @@ La conception s’inspire de la théorie de l’information intégrée : genesis
 
 La planification suit un rythme de carte logistique, faible écho de la théorie du chaos où une petite variation de temps initial peut déplacer toute la cadence du monologue d’Indiana.
 
-Fonctionnellement, le module expose `run_genesis1(mode, digest_size)` et un orchestrateur de tâche quotidienne ; ensemble, ils génèrent des résumés, mettent en file des jobs de fond et journalisent les murmures récoltés.
+Fonctionnellement, le module expose `run_genesis1(digest_size)` et un orchestrateur de tâche quotidienne ; ensemble, ils génèrent des résumés, mettent en file des jobs de fond et journalisent les murmures récoltés.
 
 Philosophiquement, genesis1 agit comme un phénoménologue errant, réduisant les expériences brutes du jour à une essence suspendue entre noèse et noème.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The design nods to Integrated Information Theory: genesis1 increases Φ by bindi
 
 Scheduling is governed by a logistic-map rhythm, a faint echo of chaos theory where a small tweak in seed time can shift the entire cadence of Indiana’s monologue.
 
-Functionally, the module exposes `run_genesis1(mode, digest_size)` and a daily task orchestrator; together they generate summaries, queue background jobs, and log the whispers they harvest.
+Functionally, the module exposes `run_genesis1(digest_size)` and a daily task orchestrator; together they generate summaries, queue background jobs, and log the whispers they harvest.
 
 Philosophically, genesis1 behaves like a wandering phenomenologist, reducing the day’s raw experiences to an essence that hovers between noesis and noema.
 

--- a/utils/genesis1.py
+++ b/utils/genesis1.py
@@ -64,13 +64,11 @@ async def _call_perplexity(query: str, size: int) -> str:
         return resp.json()["choices"][0]["message"]["content"].strip()
 
 # ====== основной вызов ======
-async def run_genesis1(mode: str = "silent", digest_size: int = 150) -> str | None:
+async def run_genesis1(digest_size: int = 150) -> str | None:
     """Запустить Genesis-1 и вернуть полученный дайджест.
 
     Parameters
     ----------
-    mode:
-        ``"silent"`` или ``"normal"``. В первом случае вывод подавляется.
     digest_size:
         Ориентировочный размер выжимки в словах.
     Returns
@@ -115,9 +113,6 @@ async def run_genesis1(mode: str = "silent", digest_size: int = 150) -> str | No
         pass
 
     # 5. Вывод
-    if mode != "silent":
-        logger.info(f"[Genesis-1 Fact]\n{digest}\n")
-    else:
-        logger.info("[Genesis-1] Saved internally.")
+    logger.info(f"[Genesis-1 Fact]\n{digest}\n")
 
     return digest


### PR DESCRIPTION
## Summary
- always log Genesis-1 digests and drop silent mode parameter
- remove `/silent` and `/nosilent` commands and menu entries
- update documentation for new `run_genesis1(digest_size)` signature

## Testing
- `python -m flake8 main.py utils/genesis1.py`
- `pytest tests/test_rate_limit.py`


------
https://chatgpt.com/codex/tasks/task_e_689d1d0e420083298d44cc20215c67d3