### PR TITLE
Add safe archive extraction

### DIFF
--- a/utils/archive.py
+++ b/utils/archive.py
@@ -1,0 +1,39 @@
+import logging
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+Archive = Union[zipfile.ZipFile, tarfile.TarFile]
+
+def safe_extract(archive: Archive, dest: str) -> None:
+    """Safely extract an archive to *dest* ensuring no path traversal.
+
+    Raises RuntimeError if a member tries to escape the destination
+    directory. Any extraction errors are logged and re-raised.
+    """
+    dest_path = Path(dest).resolve()
+    try:
+        if isinstance(archive, zipfile.ZipFile):
+            members = archive.namelist()
+            for member in members:
+                member_path = dest_path / member
+                if not member_path.resolve().is_relative_to(dest_path):
+                    logger.warning("Path traversal attempt in zip member: %s", member)
+                    raise RuntimeError(f"Unsafe path detected: {member}")
+            archive.extractall(dest_path)
+        elif isinstance(archive, tarfile.TarFile):
+            members = archive.getmembers()
+            for member in members:
+                member_path = dest_path / member.name
+                if not member_path.resolve().is_relative_to(dest_path):
+                    logger.warning("Path traversal attempt in tar member: %s", member.name)
+                    raise RuntimeError(f"Unsafe path detected: {member.name}")
+            archive.extractall(dest_path)
+        else:
+            raise TypeError("Unsupported archive type")
+    except Exception:
+        logger.exception("Failed to safely extract archive")
+        raise


### PR DESCRIPTION
## Summary
- add `safe_extract` helper preventing path traversal when extracting archives
- replace direct archive extraction in `context_neural_processor` with `safe_extract`

## Testing
- `flake8 utils/archive.py utils/context_neural_processor.py`
- `pytest` *(fails: 11 failed, 79 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689d24446f248329a8cdd936752b20e9