### PR TITLE
feat: add ttl to lru cache

### DIFF
--- a/utils/lru_cache.py
+++ b/utils/lru_cache.py
@@ -1,15 +1,21 @@
-from collections import OrderedDict
 import time
+from collections import OrderedDict
 
 
 class LRUCache:
     """Simple LRU cache with max length and TTL support."""
 
-    def __init__(self, maxlen: int = 1024):
+    def __init__(self, maxlen: int = 1024, ttl: float | None = None):
         self.maxlen = maxlen
+        self.ttl = ttl
         self._data: OrderedDict[str, tuple[str, float]] = OrderedDict()
 
     def get(self, key: str, default=None):
+        if self.ttl is not None:
+            cutoff = time.time() - self.ttl
+            keys = [k for k, (_, ts) in self._data.items() if ts < cutoff]
+            for k in keys:
+                del self._data[k]
         item = self._data.get(key)
         if item is None:
             return default


### PR DESCRIPTION
## Summary
- allow LRUCache to accept an optional ttl
- prune expired cache entries when accessing values

## Testing
- `flake8 utils/lru_cache.py`
- `pytest tests/test_rate_limiter.py`

------
https://chatgpt.com/codex/tasks/task_e_689d5594ee0c8329843537fcf437cd3f