### PR TITLE
Use TTL caches for user state tracking

### DIFF
--- a/tests/test_coder_help_integration.py
+++ b/tests/test_coder_help_integration.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 import random
+from datetime import datetime, timezone
 
 import pytest
 
@@ -35,7 +36,7 @@ class DummySender:
 async def test_coder_help_returns_core_commands(monkeypatch):
     main.CODER_USERS.clear()
     m = DummyMessage("/help")
-    main.CODER_USERS.add(str(m.from_user.id))
+    main.CODER_USERS.set(str(m.from_user.id), datetime.now(timezone.utc).isoformat())
 
     monkeypatch.setattr(main, "ChatActionSender", lambda **kwargs: DummySender())
 
@@ -70,9 +71,9 @@ async def test_coder_help_returns_core_commands(monkeypatch):
 @pytest.mark.asyncio
 async def test_coder_ignored_during_rawthinking():
     main.CODER_USERS.clear()
-    main.RAW_THINKING_USERS.add("123")
+    main.RAW_THINKING_USERS.set("123", datetime.now(timezone.utc).isoformat())
     m = DummyMessage("/coder")
     await main.enable_coder(m)
     assert m.answers == []
-    assert "123" not in main.CODER_USERS
+    assert main.CODER_USERS.get("123") is None
     main.RAW_THINKING_USERS.clear()

--- a/tests/test_rawthinking_mode.py
+++ b/tests/test_rawthinking_mode.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 import asyncio
+from datetime import datetime, timezone
 
 import pytest
 
@@ -30,7 +31,7 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_rawthinking_chain(monkeypatch):
-    main.RAW_THINKING_USERS.add("123")
+    main.RAW_THINKING_USERS.set("123", datetime.now(timezone.utc).isoformat())
     main.EMERGENCY_MODE = False
     m = DummyMessage("What is life?")
     

--- a/utils/lru_cache.py
+++ b/utils/lru_cache.py
@@ -31,6 +31,14 @@ class LRUCache:
         if len(self._data) > self.maxlen:
             self._data.popitem(last=False)
 
+    def delete(self, key: str) -> None:
+        """Remove ``key`` from the cache if present."""
+        self._data.pop(key, None)
+
+    def clear(self) -> None:
+        """Remove all items from the cache."""
+        self._data.clear()
+
     def cleanup(self, max_age: float) -> None:
         cutoff = time.time() - max_age
         keys = [k for k, (_, ts) in self._data.items() if ts < cutoff]


### PR DESCRIPTION
## Summary
- replace global user state sets with TTL-based `LRUCache`
- record timestamps for user state entries and schedule periodic cleanup
- extend `LRUCache` with delete/clear helpers and update tests

## Testing
- `flake8 main.py utils/lru_cache.py tests/test_coder_help_integration.py tests/test_rawthinking_mode.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d6131f26c8329890cecf641c78f40