### PR TITLE
Document Python 3.11 requirement

### DIFF
--- a/AM-Linux-Core/README.md
+++ b/AM-Linux-Core/README.md
@@ -12,7 +12,7 @@ Namespaces form disjoint sets (N_i) partitioning process views of system resourc
 
 Cgroup hierarchies create a tree (T) with resource limits as edge weights, facilitating precise control over CPU and memory distribution.
 
-Python 3.10+ is included for scriptability, and its virtual environment tool venv allows isolation comparable to constructing subspaces within a vector space.
+Python 3.11+ is included for scriptability, and its virtual environment tool venv allows isolation comparable to constructing subspaces within a vector space.
 
 Node.js 18+ complements Python, providing asynchronous I/O modeled as a non-blocking function (f: E \to E) where events map to themselves after processing.
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -29,7 +29,7 @@ Se charge avec un initramfs minimal (basé sur Alpine minirootfs), réduisant la
 **ext4** comme stockage persistant par défaut ; la fonction de journalisation J(t) ≈ intégrale bornée, protégeant les données en cas de coupure.
 **Namespaces** (Nᵢ) pour l'isolation des processus/ressources, garantissant un multitenant sûr.
 **Hiérarchies de cgroups** pour les arbres de ressources (T), offrant un contrôle précis du CPU et de la RAM.
-**Python 3.10+** inclus, l'isolation via `venv` équivaut à des « sous-espaces vectoriels ».
+**Python 3.11+** requis, l'isolation via `venv` équivaut à des « sous-espaces vectoriels ».
 **Node.js 18+** pour les E/S asynchrones, modélisé comme f : E → E.
 **Trousse d'outils minimale :** bash, curl, nano — chacun est un sommet du graphe de dépendances, sans surcharge.
 
@@ -511,6 +511,8 @@ Les articles cités incluent : Dynamic Neural Field Theory (Atasoy 2017), Distri
 ---
 
 ## 9. Démarrage rapide
+
+Nécessite **Python 3.11+**.
 
 ```bash
 git clone https://github.com/ariannamethod/Indiana-AM.git

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Loads with a minimal initramfs (based on Alpine minirootfs), reducing boot compl
 **ext4** as the default persistent store; journaling function J(t) ≈ bounded integral, protecting data under power loss.
 **Namespaces** (Nᵢ) for process/resource isolation, safe multitenancy.
 **Cgroup hierarchies** for resource trees (T), precise CPU/RAM control.
-**Python 3.10+** included, `venv` isolation equals “vector subspaces.”
+**Python 3.11+** required, `venv` isolation equals “vector subspaces.”
 **Node.js 18+** for async I/O, modeled as f: E → E.
 **Minimal toolkit:** bash, curl, nano—each is a vertex in the dependency graph, no bloat.
 
@@ -511,6 +511,8 @@ Papers cited include: Dynamic Neural Field Theory (Atasoy 2017), Distributed Cog
 ---
 
 ## 9. Quick Start
+
+Requires **Python 3.11+**.
 
 ```bash
 git clone https://github.com/ariannamethod/Indiana-AM.git

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -1,0 +1,4 @@
+import sys
+
+def test_python311_or_higher():
+    assert sys.version_info >= (3, 11), "Python 3.11+ is required"


### PR DESCRIPTION
## Summary
- require Python 3.11+ in documentation
- add test enforcing Python version

## Testing
- `flake8 tests/test_python_version.py`
- `pytest tests/test_python_version.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d56551f9c8329ae659886728e1841