### PR TITLE
Delete temporary voice files after transcription

### DIFF
--- a/main.py
+++ b/main.py
@@ -902,6 +902,10 @@ async def handle_message(m: types.Message):
             voice_path = VOICE_DIR / f"{file_info.file_unique_id}.ogg"
             await bot.download_file(file_info.file_path, destination=voice_path)
             text = await voice_to_text(client, voice_path)
+            try:
+                voice_path.unlink()
+            except Exception as e:
+                logger.error(f"Failed to delete voice file {voice_path}: {e}")
 
         user_id = str(m.from_user.id)
         chat_id = m.chat.id

--- a/tests/test_voice_cleanup.py
+++ b/tests/test_voice_cleanup.py
@@ -1,0 +1,53 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402
+
+
+class DummyVoice:
+    file_id = "voice123"
+
+
+class DummyMessage:
+    def __init__(self, voice):
+        self.text = None
+        self.voice = voice
+        self.from_user = SimpleNamespace(id=1, language_code="en")
+        self.chat = SimpleNamespace(id=1, type="private")
+        self.answers = []
+
+    async def answer(self, text: str):
+        self.answers.append(text)
+
+
+@pytest.mark.asyncio
+async def test_voice_file_removed(monkeypatch, tmp_path):
+    main.VOICE_DIR = tmp_path
+    main.EMERGENCY_MODE = True
+    main.client = object()
+
+    async def fake_get_file(file_id):
+        return SimpleNamespace(file_path="path", file_unique_id="abc")
+
+    async def fake_download_file(file_path, destination):
+        destination.write_text("voice")
+
+    async def fake_voice_to_text(client, file_path):
+        return "transcribed"
+
+    async def fake_run(cmd):
+        return "run"
+
+    main.bot = SimpleNamespace(get_file=fake_get_file, download_file=fake_download_file)
+    monkeypatch.setattr(main, "voice_to_text", fake_voice_to_text)
+    monkeypatch.setattr(main.terminal, "run", fake_run)
+
+    m = DummyMessage(DummyVoice())
+    await main.handle_message(m)
+
+    assert not (tmp_path / "abc.ogg").exists()


### PR DESCRIPTION
## Summary
- remove transcribed voice messages and log cleanup errors
- add test ensuring voice files are deleted

## Testing
- `flake8 main.py tests/test_voice_cleanup.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8b7476448329a95846f6ad3c8cd5