### PR TITLE
Cap rate limiter timestamp list

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,8 +133,10 @@ def is_rate_limited(user_id: str, now: datetime | None = None) -> bool:
     timestamps = USER_MESSAGE_TIMES.get(user_id, [])
     timestamps = [ts for ts in timestamps if now - ts < RATE_PERIOD]
     timestamps.append(now)
+    is_limited = len(timestamps) > RATE_LIMIT
+    timestamps = timestamps[-RATE_LIMIT:]
     USER_MESSAGE_TIMES.set(user_id, timestamps)
-    return len(timestamps) > RATE_LIMIT
+    return is_limited
 
 complexity_logger = ThoughtComplexityLogger()
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -43,3 +43,11 @@ async def test_rate_limiter_stops_responses(monkeypatch):
 
     assert m.answers, "warning should be sent when rate limit exceeded"
     assert "слишком часто" in m.answers[0].lower()
+
+
+def test_timestamp_list_capped():
+    USER_MESSAGE_TIMES._data.clear()
+    user_id = "123"
+    for _ in range(RATE_LIMIT * 2):
+        is_rate_limited(user_id)
+    assert len(USER_MESSAGE_TIMES.get(user_id, [])) == RATE_LIMIT


### PR DESCRIPTION
## Summary
- prevent `USER_MESSAGE_TIMES` from growing past the configured `RATE_LIMIT`
- add regression test ensuring timestamp list remains capped

## Testing
- `flake8 main.py tests/test_rate_limit.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8c0241508329ab688478adaaeab4