### PR TITLE
Add command validation and audit logging

### DIFF
--- a/utils/aml_terminal.py
+++ b/utils/aml_terminal.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 
-from utils.security import is_blocked, log_blocked
+from utils.security import log_blocked, validate_command
 
 
 class AriannaTerminal:
@@ -63,8 +63,9 @@ class AriannaTerminal:
 
     async def run(self, cmd: str) -> str:
         real_cmd = cmd[5:] if cmd.startswith("/run ") else cmd
-        if is_blocked(real_cmd):
-            log_blocked(real_cmd)
+        allowed, reason = validate_command(real_cmd)
+        if not allowed:
+            log_blocked(real_cmd, reason)
             return "Терминал закрыт"
         await self._ensure_started()
         if not self.proc or not self.proc.stdin or not self.proc.stdout:

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -13,7 +13,7 @@ from openai import OpenAI
 
 from utils.aml_terminal import terminal
 from utils.genesis2 import genesis2_sonar_filter
-from utils.security import is_blocked, log_blocked
+from utils.security import log_blocked, validate_command
 
 # Import core command definitions from the LetsGo terminal
 CORE_DIR = Path(__file__).resolve().parent.parent / "AM-Linux-Core"
@@ -159,8 +159,9 @@ async def kernel_exec(command: str) -> str:
     The command is executed inside the Arianna core environment and all
     activity is logged under ``/arianna_core/log``.
     """
-    if is_blocked(command):
-        log_blocked(command)
+    allowed, reason = validate_command(command)
+    if not allowed:
+        log_blocked(command, reason)
         base = "Ты и правда думал, что это сработает? Нет, дружище! Терминал закрыт."
         twist = await genesis2_sonar_filter(command, base, "ru")
         message = f"{base} {twist}".strip()


### PR DESCRIPTION
## Summary
- add `validate_command` to verify shell commands and arguments via `shlex` and log block reasons
- integrate validator into terminal and coder modules to enforce command whitelisting

## Testing
- `flake8 utils/security.py utils/aml_terminal.py utils/coder.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d8cb4d1b483299d6005115cdcc9f8