### PR TITLE
Persist local vector store between runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ PINECONE_INDEX=your-pinecone-index-name
 PINECONE_ENV=your-pinecone-environment
 EMBED_MODEL=text-embedding-3-small
 VECTOR_STORE_MAX_SIZE=1000
+VECTOR_STORE_PATH=vector_store.json
 ANTHROPIC_API_KEY=your-anthropic-key
 XAI_API_KEY=your-xai-key
 GEMINI_GRAVITY_KEY=your-gemini-key

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Requires **Python 3.11+**.
 ```bash
 git clone https://github.com/ariannamethod/Indiana-AM.git
 cd Indiana-AM
-cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PPLX_API_KEY, etc.
+cp .env.example .env   # add TELEGRAM_TOKEN, OPENAI_API_KEY, PPLX_API_KEY, VECTOR_STORE_PATH, etc.
 # also set AGENT_GROUP_ID, GROUP_CHAT, CREATOR_CHAT, PINECONE_API_KEY and EMBED_MODEL
 # `.env` auto-loads on startup
 # After first run, assistant IDs are stored in `assistants.json`

--- a/main.py
+++ b/main.py
@@ -93,7 +93,15 @@ client = AsyncOpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 ASSISTANT_ID = None
 
 # Vector store and memory manager
-vector_store = create_vector_store(max_size=settings.VECTOR_STORE_MAX_SIZE)
+VECTOR_STORE_PATH = Path(settings.VECTOR_STORE_PATH)
+if VECTOR_STORE_PATH.exists():
+    logger.info("Loading vector store from %s", VECTOR_STORE_PATH)
+else:
+    logger.info("Vector store file %s not found; starting new", VECTOR_STORE_PATH)
+vector_store = create_vector_store(
+    max_size=settings.VECTOR_STORE_MAX_SIZE,
+    persist_path=str(VECTOR_STORE_PATH),
+)
 memory = MemoryManager(db_path="lighthouse_memory.db", vectorstore=vector_store)
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -31,6 +31,7 @@ class Settings:
     RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
     RATE_LIMIT_DELAY: float = float(os.getenv("RATE_LIMIT_DELAY", 0))
     VECTOR_STORE_MAX_SIZE: int | None = _get_vector_store_max_size()
+    VECTOR_STORE_PATH: str = os.getenv("VECTOR_STORE_PATH", "vector_store.json")
 
     def __post_init__(self) -> None:
         required = {


### PR DESCRIPTION
## Summary
- make vector store path configurable via `VECTOR_STORE_PATH`
- load existing local vectors at startup and log source
- document new `VECTOR_STORE_PATH` env var

## Testing
- `flake8 main.py utils/config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d8cc88fc88329b2a8585c0fd3e3c6