### PR TITLE
Add configurable security patterns and tests

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,26 @@
+import importlib
+import json
+
+import utils.security as security
+
+
+def test_allowed_command_not_blocked():
+    assert not security.is_blocked("echo hello")
+
+
+def test_blocked_command_is_blocked():
+    assert security.is_blocked("rm -rf /")
+
+
+def test_load_config_from_file(monkeypatch, tmp_path):
+    config = {"allowed": [r"^foo$"], "suspicious": [r"bar"]}
+    cfg_path = tmp_path / "security.json"
+    cfg_path.write_text(json.dumps(config), encoding="utf-8")
+    monkeypatch.setenv("SECURITY_CONFIG_PATH", str(cfg_path))
+    importlib.reload(security)
+    try:
+        assert not security.is_blocked("foo")
+        assert security.is_blocked("echo hello")
+    finally:
+        monkeypatch.delenv("SECURITY_CONFIG_PATH", raising=False)
+        importlib.reload(security)


### PR DESCRIPTION
## Summary
- allow security patterns to be loaded from JSON config via `SECURITY_CONFIG_PATH`
- add tests for blocking and allowing commands and for config loading

## Testing
- `python -m py_compile utils/security.py tests/test_security.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8d42434883298742a3be365f35b4