### PR TITLE
Gracefully handle cancellation in background tasks

### DIFF
--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -29,7 +29,43 @@ async def test_background_task_exception_logged(monkeypatch):
     task = main.task_group.create_task(boom())
     main.background_tasks.append(task)
 
+    await asyncio.sleep(0)
     await main.on_shutdown(None)
 
     error_exc_infos = [call.kwargs.get("exc_info") for call in mock_logger.error.call_args_list]
     assert any(isinstance(e, ValueError) and str(e) == "boom" for e in error_exc_infos)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_tasks_terminate(monkeypatch, tmp_path):
+    """Background cleanup tasks should finish without errors when cancelled."""
+    monkeypatch.setattr(main.repo_watcher, "stop", MagicMock())
+    monkeypatch.setattr(main.memory, "close", AsyncMock())
+    monkeypatch.setattr(main.knowtheworld.memory, "close", AsyncMock())
+    monkeypatch.setattr(main, "VOICE_DIR", tmp_path)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(*_, **__):
+        await real_sleep(0)
+
+    monkeypatch.setattr(main.asyncio, "sleep", fast_sleep)
+
+    main.background_tasks.clear()
+    main.task_group = asyncio.TaskGroup()
+    await main.task_group.__aenter__()
+
+    tasks = [
+        main.task_group.create_task(main.cleanup_old_voice_files()),
+        main.task_group.create_task(main.cleanup_user_langs()),
+        main.task_group.create_task(main.cleanup_user_states()),
+    ]
+    main.background_tasks.extend(tasks)
+
+    await asyncio.sleep(0)  # let tasks start
+
+    await main.on_shutdown(None)
+
+    for t in tasks:
+        assert t.done()
+        assert t.exception() is None


### PR DESCRIPTION
## Summary
- gracefully exit periodic cleanup loops on `asyncio.CancelledError`
- cancel TaskGroup children during shutdown
- test background task termination and error logging

## Testing
- `flake8 main.py tests/test_background_tasks.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8d770f4083299cf3c1db1604cb49