### PR TITLE
Add file size validation to voice transcription

### DIFF
--- a/tests/test_voice_file_size.py
+++ b/tests/test_voice_file_size.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.voice import voice_to_text, MAX_FILE_SIZE  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_voice_file_too_large(tmp_path):
+    bigfile = tmp_path / "big.ogg"
+    bigfile.write_bytes(b"0" * (MAX_FILE_SIZE + 1))
+    with pytest.raises(ValueError):
+        await voice_to_text(object(), bigfile)

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from openai import AsyncOpenAI
 
 
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+
 async def text_to_voice(client: AsyncOpenAI, text: str) -> bytes:
     """Generate speech audio from text using OpenAI TTS."""
     response = await client.audio.speech.create(
@@ -16,6 +19,8 @@ async def text_to_voice(client: AsyncOpenAI, text: str) -> bytes:
 
 async def voice_to_text(client: AsyncOpenAI, file_path: Path) -> str:
     """Transcribe speech audio to text using Whisper."""
+    if file_path.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError("File size exceeds 10MB limit")
     with file_path.open("rb") as f:
         response = await client.audio.transcriptions.create(
             model="whisper-1",


### PR DESCRIPTION
## Summary
- limit voice transcription uploads to 10MB
- test that oversized audio raises `ValueError`

## Testing
- `flake8 utils/voice.py tests/test_voice_file_size.py`
- `pytest` *(fails: module 'utils.security' has no attribute 'is_blocked', assertions in terminal tests)*
- `pytest tests/test_voice_file_size.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dadace8d48329b9537ef903632e3d