### PR TITLE
Handle missing XAI API key and HTTP errors in indiana_b

### DIFF
--- a/tests/test_indiana_b.py
+++ b/tests/test_indiana_b.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import indiana_b  # noqa: E402
+from indiana_b import badass_indiana_chat  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_missing_xai_api_key(monkeypatch, caplog):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(indiana_b, "XAI_API_KEY", None, raising=False)
+    with caplog.at_level("ERROR"):
+        result = await badass_indiana_chat("test")
+    assert "XAI_API_KEY" in caplog.text
+    assert result == "XAI_API_KEY is missing"


### PR DESCRIPTION
## Summary
- log missing `XAI_API_KEY` and return a safe error message before making Grok-3 requests
- guard `httpx` call with `HTTPError` handling to avoid crashing on network issues
- add unit test covering behaviour when the API key is absent

## Testing
- `python -m flake8 indiana_b.py tests/test_indiana_b.py`
- `pytest tests/test_indiana_b.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dada222c48329a357da014baac9dd