### PR TITLE
refactor: centralize logging with weekly rotation

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -278,7 +278,7 @@ La synthèse passe par `genesis2_sonar_filter`, de sorte que la réponse finale 
 
 L’entropie de Markov et la perplexité d’un micro‑GPT sont calculées, traitant la conversation comme un champ stochastique dont on mesure la surprise.
 
-Chaque échange est consigné dans `/arianna_core/log/rawthinking.log`, fournissant une trace d’audit de chaque consilium.
+Chaque échange est consigné dans `logs/indiana.log` avec rotation hebdomadaire et compression gzip, fournissant une trace d’audit de chaque consilium.
 
 Rawthinking ne remplace pas le mode thinking existant ; il surgit seulement quand on l’appelle par la commande `/rawthinking`.
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The synthesis passes through `genesis2_sonar_filter`, so the final answer carrie
 
 Markov entropy and micro‑GPT perplexity are computed, treating the conversation as a stochastic field whose surprise can be quantified.
 
-All exchanges are logged to `/arianna_core/log/rawthinking.log`, providing an audit trail of every consilium.
+All exchanges are logged to `logs/indiana.log` with weekly rotation and gzip compression, providing an audit trail of every consilium.
 
 Rawthinking does not replace the existing thinking mode; it emerges only when explicitly summoned with `/rawthinking`.
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from utils.complexity import (
     ThoughtComplexityLogger,
     estimate_complexity_and_entropy,
 )
+from utils.logging_config import setup_logging
 from langdetect import detect, DetectorFactory, LangDetectException
 from utils.repo_monitor import RepoWatcher
 from utils.voice import text_to_voice, voice_to_text
@@ -46,11 +47,7 @@ from indiana_d import techno_indiana_chat
 from indiana_g import gravity_indiana_chat
 from GENESIS_orchestrator import update_and_train, report_entropy
 
-# Настройка логгера
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
+setup_logging()
 logger = logging.getLogger(__name__)
 
 load_dotenv()

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -25,14 +25,7 @@ from letsgo import CORE_COMMANDS  # type: ignore  # noqa: E402
 api_key = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=api_key) if api_key else None
 
-LOG_FILE = Path(__file__).resolve().parent.parent / "artefacts" / "coder.log"
 logger = logging.getLogger("coder")
-if not logger.handlers:
-    handler = logging.FileHandler(LOG_FILE)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 # Root directory of the repository for path validation
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/utils/context_neural_processor.py
+++ b/utils/context_neural_processor.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import random
 import re
 import json
-from datetime import datetime
 import logging
 
 from .archive import safe_extract
@@ -88,27 +87,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_MAX_TEXT_SIZE = 100_000
 DEFAULT_MAX_ARCHIVE_SIZE = 10_000_000  # 10 MB
 REPO_SNAPSHOT_PATH = BASE_DIR / "config/repo_snapshot.md"
-LOG_DIR = BASE_DIR / "logs/context_neural_processor"
-FAIL_DIR = BASE_DIR / "logs/failures"
 CACHE_DB = BASE_DIR / "cache/context_neural_cache.db"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
-FAIL_DIR.mkdir(parents=True, exist_ok=True)
 CACHE_DB.parent.mkdir(parents=True, exist_ok=True)
 
 
 def log_event(msg: str, log_type: str = "info") -> None:
-    """Write ``msg`` to the context neural processor log and failures log if needed."""
+    """Log ``msg`` using the standard logging configuration."""
 
-    entry = {
-        "timestamp": datetime.utcnow().isoformat(),
-        "type": log_type,
-        "msg": msg,
-    }
-    with (LOG_DIR / f"{datetime.utcnow().date()}.jsonl").open("a", encoding="utf-8") as f:
-        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    if log_type == "error":
-        with (FAIL_DIR / f"{datetime.utcnow().date()}.jsonl").open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    level = getattr(logger, log_type, logger.info)
+    level(msg)
 
 
 def apply_pulse(weights: List[float], pulse: float) -> List[float]:

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -1,0 +1,39 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+import gzip
+import shutil
+
+LOG_DIR = Path("logs")
+LOG_FILE = LOG_DIR / "indiana.log"
+
+def setup_logging() -> None:
+    """Configure root logger with weekly rotating gzip-compressed file handler."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    if logging.getLogger().handlers:
+        return
+    handler = TimedRotatingFileHandler(
+        LOG_FILE, when="W0", backupCount=8, encoding="utf-8"
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+
+    def namer(name: str) -> str:
+        return f"{name}.gz"
+
+    def rotator(source: str, dest: str) -> None:
+        with open(source, "rb") as f_in, gzip.open(dest, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        Path(source).unlink(missing_ok=True)
+
+    handler.namer = namer
+    handler.rotator = rotator
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+
+
+setup_logging()

--- a/utils/rawthinking.py
+++ b/utils/rawthinking.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pathlib import Path
 
 from openai import AsyncOpenAI
 
@@ -17,9 +16,6 @@ from GENESIS_orchestrator.entropy import markov_entropy, model_perplexity
 logger = logging.getLogger(__name__)
 
 client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None
-
-LOG_FILE = Path("/arianna_core/log/rawthinking.log")
-
 
 async def synthesize_final(
     prompt: str,
@@ -87,24 +83,17 @@ async def synthesize_final(
     except Exception as e:
         logger.error("Perplexity calc failed: %s", e)
 
-    try:
-        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with LOG_FILE.open("a", encoding="utf-8") as f:
-            f.write(
-                "Q: {q}\nB: {b}\nC: {c}\nD: {d}\nG: {g}\nFinal: {f}\n"
-                "Entropy: {e:.2f} | Perplexity: {p:.2f}\n---\n".format(
-                    q=prompt,
-                    b=b_resp or "—",
-                    c=c_resp or "—",
-                    d=d_resp or "—",
-                    g=g_resp or "—",
-                    f=final_reply,
-                    e=entropy,
-                    p=perplexity,
-                )
-            )
-    except Exception as e:
-        logger.error("Failed to log rawthinking: %s", e)
+    logger.info(
+        "Q: %s\nB: %s\nC: %s\nD: %s\nG: %s\nFinal: %s\nEntropy: %.2f | Perplexity: %.2f\n---",
+        prompt,
+        b_resp or "—",
+        c_resp or "—",
+        d_resp or "—",
+        g_resp or "—",
+        final_reply,
+        entropy,
+        perplexity,
+    )
 
     return final_reply
 

--- a/utils/security.py
+++ b/utils/security.py
@@ -2,28 +2,11 @@ import logging
 import re
 import shlex
 from collections.abc import Callable
-from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
 LOG_FILE = Path("artefacts/blocked_commands.log")
-LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 logger = logging.getLogger("security")
-
-
-def _configure_logger() -> None:
-    if logger.handlers:
-        return
-    handler = TimedRotatingFileHandler(
-        LOG_FILE, when="midnight", backupCount=7, encoding="utf-8"
-    )
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-
-
-_configure_logger()
 
 # Whitelist of allowed commands and their permitted arguments
 # ``None`` means any arguments are allowed, an empty set means no arguments.
@@ -121,7 +104,6 @@ def validate_command(command: str) -> tuple[bool, str | None]:
 def log_blocked(command: str, reason: str) -> None:
     """Log a blocked command attempt with the reason."""
 
-    _configure_logger()
     logger.error("Blocked command: %s - %s", command, reason)
     for handler in logger.handlers:
         handler.flush()


### PR DESCRIPTION
## Summary
- centralize logging with a weekly gzipped rotating file
- switch modules to shared logging config and remove manual file writes
- document new `logs/indiana.log` location

## Testing
- `flake8 utils/rawthinking.py utils/coder.py utils/security.py utils/context_neural_processor.py main.py tests/test_coder.py tests/test_terminal.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbb66eac48329b484871046251f76