### PR TITLE
feat: track user ID in blocked command logs

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -42,18 +42,21 @@ def test_blocked_command_and_logging(temp_security_log, caplog):
     """Disallowed commands are flagged and logged."""
 
     caplog.set_level(logging.WARNING, logger="security")
-    assert security.is_blocked("rm -rf /") is True
+    assert security.is_blocked("rm -rf /", user_id="alice") is True
     assert any("Suspicious command sequence" in r.message for r in caplog.records)
+    assert "alice" in caplog.text
 
     caplog.clear()
     caplog.set_level(logging.ERROR, logger="security")
-    security.log_blocked("rm -rf /", "manual reason")
+    security.log_blocked("rm -rf /", "manual reason", user_id="bob")
     assert "Blocked command" in caplog.text
+    assert "bob" in caplog.text
 
     # Ensure log file records the blocked command
     log_text = temp_security_log.read_text(encoding="utf-8")
     assert "Blocked command" in log_text
     assert "manual reason" in log_text
+    assert "bob" in log_text
 
 
 def test_cat_path_validation():

--- a/utils/aml_terminal.py
+++ b/utils/aml_terminal.py
@@ -68,11 +68,11 @@ class AriannaTerminal:
     def is_running(self) -> bool:
         return bool(self.proc) and self.proc.returncode is None
 
-    async def run(self, cmd: str) -> str:
+    async def run(self, cmd: str, user_id: str | None = None) -> str:
         real_cmd = cmd[5:] if cmd.startswith("/run ") else cmd
-        allowed, reason = validate_command(real_cmd)
+        allowed, reason = validate_command(real_cmd, user_id)
         if not allowed:
-            log_blocked(real_cmd, reason)
+            log_blocked(real_cmd, reason, user_id)
             return "Терминал закрыт"
         if not self.is_running():
             if self.proc and self.proc.returncode is not None:

--- a/utils/coder.py
+++ b/utils/coder.py
@@ -146,21 +146,21 @@ async def generate_code(request: str) -> DraftResponse:
     return await CODER_SESSION.draft(request)
 
 
-async def kernel_exec(command: str) -> str:
+async def kernel_exec(command: str, user_id: str | None = None) -> str:
     """Run a shell command through the AM-Linux kernel via letsgo.
 
     The command is executed inside the Arianna core environment and all
     activity is logged under ``/arianna_core/log``.
     """
-    allowed, reason = validate_command(command)
+    allowed, reason = validate_command(command, user_id)
     if not allowed:
-        log_blocked(command, reason)
+        log_blocked(command, reason, user_id)
         base = "Ты и правда думал, что это сработает? Нет, дружище! Терминал закрыт."
         twist = await genesis2_sonar_filter(command, base, "ru")
         message = f"{base} {twist}".strip()
         await terminal.stop()
         return message
-    return await terminal.run(f"/run {command}")
+    return await terminal.run(f"/run {command}", user_id)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- allow passing optional user_id through command validation and logging
- propagate user_id from terminal and coder to security logging
- record user_id in blocked command log entries

## Testing
- `python -m flake8 utils/security.py utils/aml_terminal.py utils/coder.py tests/test_security.py tests/test_terminal.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dd8136cc88329b5f5e1b857526cca