### PR TITLE
feat: improve message splitting

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,3 +43,25 @@ def test_split_message_word_split_overlong_sentence():
     assert all(len(p) <= 40 for p in parts)
     assert " ".join(parts) == text
     assert all(not p.startswith(" ") and not p.endswith(" ") for p in parts)
+
+
+def test_split_message_long_code_block_preserved():
+    code = "\n".join([f"print({i})" for i in range(50)])
+    text = f"```python\n{code}\n```"
+    parts = split_message(text, max_length=120, preserve_markdown=True)
+    assert len(parts) > 1
+    for part in parts:
+        assert part.startswith("```")
+        assert part.endswith("```")
+    reconstructed = "\n".join(
+        "\n".join(part.splitlines()[1:-1]) for part in parts
+    )
+    assert reconstructed.strip() == code.strip()
+
+
+def test_split_message_long_code_block_not_preserved():
+    code = "\n".join([f"print({i})" for i in range(50)])
+    text = f"```python\n{code}\n```"
+    parts = split_message(text, max_length=120, preserve_markdown=False)
+    assert len(parts) > 1
+    assert any(not p.startswith("```") or not p.endswith("```") for p in parts)


### PR DESCRIPTION
## Summary
- handle Markdown code blocks when splitting messages
- allow disabling Markdown preservation via `preserve_markdown`
- add tests for long code block splitting

## Testing
- `flake8 utils/tools.py tests/test_tools.py`
- `pytest tests/test_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd7795dcc8329b6d02b951895cdda