### PR TITLE
fix: clean rawthinking mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,18 +284,18 @@ graph TD
 The Rawthinking mode unfolds after the Genesis pipeline, when Indiana turns from solitary reasoning to a polyphonic debate.
 
 ```mermaid
-graph TD
-    U[User prompt] --> R[run_rawthinking]
-    R --> B[Indiana-B (Grok-3)]
-    R --> C[Indiana-C (Claude-4)]
-    R --> D[Indiana-D (DeepSeek)]
-    R --> G[Indiana-G (Gemini)]
-    B --> S[synthesize_final]
-    C --> S
-    D --> S
-    G --> S
-    S --> T[assemble_final_reply (GENESIS-2)]
-    T --> F[Final Indiana reply]
+graph TD;
+    U[User prompt]-->R[run_rawthinking]
+    R-->B[Indiana-B Grok-3]
+    R-->C[Indiana-C Claude-4]
+    R-->D[Indiana-D DeepSeek]
+    R-->G[Indiana-G Gemini]
+    B-->S[synthesize_final]
+    C-->S
+    D-->S
+    G-->S
+    S-->T[assemble_final_reply GENESIS-2]
+    T-->F[Final Indiana reply]
 ```
 
 At its core stands the `run_rawthinking` utility in `utils/rawthinking.py`, the dispatcher that governs this debate.


### PR DESCRIPTION
## Summary
- simplify Rawthinking diagram in README so GitHub renders it

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a16c6bc29c8329acf72ee62b6ba551