### PR TITLE
Fix rawthinking mermaid graphs

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -284,18 +284,18 @@ graph TD
 Le mode Rawthinking apparaît après le pipeline Genesis, lorsque Indiana passe du raisonnement solitaire à un débat polyphonique.
 
 ```mermaid
-graph TD;
-    U[Demande utilisateur] --> R[run_rawthinking];
-    R --> B[Indiana-B (Grok-3)];
-    R --> C[Indiana-C (Claude-4)];
-    R --> D[Indiana-D (DeepSeek)];
-    R --> G[Indiana-G (Gemini)];
-    B --> S[synthesize_final];
-    C --> S;
-    D --> S;
-    G --> S;
-    S --> T[assemble_final_reply (GENESIS-2)];
-    T --> F[Réponse finale d'Indiana];
+graph TD
+    U[Demande utilisateur] --> R[run_rawthinking]
+    R --> B[Indiana-B (Grok-3)]
+    R --> C[Indiana-C (Claude-4)]
+    R --> D[Indiana-D (DeepSeek)]
+    R --> G[Indiana-G (Gemini)]
+    B --> S[synthesize_final]
+    C --> S
+    D --> S
+    G --> S
+    S --> T[assemble_final_reply (GENESIS-2)]
+    T --> F[Réponse finale d'Indiana]
 ```
 
 Au centre se trouve l’utilitaire `run_rawthinking` dans `utils/rawthinking.py`, répartiteur qui gouverne ce débat.

--- a/README.md
+++ b/README.md
@@ -285,17 +285,17 @@ The Rawthinking mode unfolds after the Genesis pipeline, when Indiana turns from
 
 ```mermaid
 graph TD
-    U[User Message] --> R[run_rawthinking];
-    R --> B[Indiana-B (Grok-3)];
-    R --> C[Indiana-C (Claude-4)];
-    R --> D[Indiana-D (DeepSeek)];
-    R --> G[Indiana-G (Gemini)];
-    B --> S[synthesize_final];
-    C --> S;
-    D --> S;
-    G --> S;
-    S --> T[assemble_final_reply (GENESIS-2)];
-    T --> F[Final Indiana reply];
+    U[User Message] --> R[run_rawthinking]
+    R --> B[Indiana-B (Grok-3)]
+    R --> C[Indiana-C (Claude-4)]
+    R --> D[Indiana-D (DeepSeek)]
+    R --> G[Indiana-G (Gemini)]
+    B --> S[synthesize_final]
+    C --> S
+    D --> S
+    G --> S
+    S --> T[assemble_final_reply (GENESIS-2)]
+    T --> F[Final Indiana reply]
 ```
 
 At its core stands the `run_rawthinking` utility in `utils/rawthinking.py`, the dispatcher that governs this debate.


### PR DESCRIPTION
## Summary
- Harmonize Rawthinking mermaid diagram style in README and README-fr with Standard Reply Flow so GitHub renders the graph correctly.

## Testing
- No tests were run; documentation-only changes.

------
https://chatgpt.com/codex/tasks/task_e_68a16f70c0c48329b282a0a2d0df37e3