### PR TITLE
Simplify rawthinking diagrams in readmes

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -286,14 +286,8 @@ Le mode Rawthinking apparaît après le pipeline Genesis, lorsque Indiana passe 
 ```mermaid
 graph TD
     U[Demande utilisateur] --> R[run_rawthinking]
-    R --> B[Indiana-B (Grok-3)]
-    R --> C[Indiana-C (Claude-4)]
-    R --> D[Indiana-D (DeepSeek)]
-    R --> G[Indiana-G (Gemini)]
-    B --> S[synthesize_final]
-    C --> S
-    D --> S
-    G --> S
+    R --> Q[Indiana B/C/D/G]
+    Q --> S[synthesize_final]
     S --> T[assemble_final_reply (GENESIS-2)]
     T --> F[Réponse finale d'Indiana]
 ```

--- a/README.md
+++ b/README.md
@@ -286,14 +286,8 @@ The Rawthinking mode unfolds after the Genesis pipeline, when Indiana turns from
 ```mermaid
 graph TD
     U[User Message] --> R[run_rawthinking]
-    R --> B[Indiana-B (Grok-3)]
-    R --> C[Indiana-C (Claude-4)]
-    R --> D[Indiana-D (DeepSeek)]
-    R --> G[Indiana-G (Gemini)]
-    B --> S[synthesize_final]
-    C --> S
-    D --> S
-    G --> S
+    R --> Q[Indiana B/C/D/G]
+    Q --> S[synthesize_final]
     S --> T[assemble_final_reply (GENESIS-2)]
     T --> F[Final Indiana reply]
 ```


### PR DESCRIPTION
## Summary
- streamline mermaid graph for rawthinking mode
- apply simplified graph in both English and French README files

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a171b18cb48329802825f0b1968f37