### PR TITLE
feat: add daily message limit with bypass support

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,10 +3,10 @@ import asyncio
 import random
 import logging
 import re
+import os
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from collections import OrderedDict
-from typing import Any
 from aiogram import Bot, Dispatcher, types, F
 from aiogram.utils.chat_action import ChatActionSender
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler
@@ -22,7 +22,7 @@ from utils.config import settings
 from utils import dayandnight
 from utils import knowtheworld
 from utils.genesis1 import run_genesis1
-from utils.genesis2 import genesis2_sonar_filter, assemble_final_reply
+from utils.genesis2 import genesis2_sonar_filter
 from utils.genesis3 import genesis3_deep_dive
 from utils.genesis6 import genesis6_profile_filter
 from utils.deepdiving import perplexity_search
@@ -63,6 +63,10 @@ PINECONE_API_KEY = settings.PINECONE_API_KEY
 PINECONE_INDEX = settings.PINECONE_INDEX
 PINECONE_ENV = settings.PINECONE_ENV
 
+CONTRIBUTOR_CHAT_IDS: set[str] = {
+    cid for cid in os.getenv("CONTRIBUTOR_CHAT_IDS", "").split(",") if cid
+}
+
 # Для webhook
 BASE_WEBHOOK_URL = settings.BASE_WEBHOOK_URL  # URL вашего приложения (для Railway)
 WEBHOOK_PATH = f"/webhook/{TELEGRAM_TOKEN}"
@@ -78,9 +82,9 @@ bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher()
 dp.message.middleware(
     RateLimitMiddleware(
-        settings.RATE_LIMIT_COUNT,
-        settings.RATE_LIMIT_PERIOD,
-        settings.RATE_LIMIT_DELAY,
+        limit=settings.DAILY_MSG_LIMIT,
+        window=86400,
+        bypass_ids={CREATOR_CHAT} | CONTRIBUTOR_CHAT_IDS,
     )
 )
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -46,3 +46,30 @@ async def test_rate_limiter_logs_exceed(caplog):
         await middleware(handler, message, {})
 
     assert any("Rate limit exceeded" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_daily_limit_and_bypass():
+    middleware = RateLimitMiddleware(limit=1, window=86400, bypass_ids={"2"})
+    user1 = User(id=1, is_bot=False, first_name="User1")
+    chat1 = Chat(id=1, type="private")
+    message1 = Message(message_id=1, date=datetime.now(), chat=chat1, from_user=user1, text="hi")
+
+    calls = 0
+
+    async def handler(event, data):
+        nonlocal calls
+        calls += 1
+
+    await middleware(handler, message1, {})
+    await middleware(handler, message1, {})
+    assert calls == 1
+
+    user2 = User(id=2, is_bot=False, first_name="User2")
+    chat2 = Chat(id=2, type="private")
+    message2 = Message(message_id=1, date=datetime.now(), chat=chat2, from_user=user2, text="hi")
+
+    await middleware(handler, message2, {})
+    await middleware(handler, message2, {})
+
+    assert calls == 3

--- a/utils/config.py
+++ b/utils/config.py
@@ -29,6 +29,7 @@ class Settings:
     RATE_LIMIT_COUNT: int = int(os.getenv("RATE_LIMIT_COUNT", 20))
     RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
     RATE_LIMIT_DELAY: float = float(os.getenv("RATE_LIMIT_DELAY", 0))
+    DAILY_MSG_LIMIT: int = int(os.getenv("DAILY_MSG_LIMIT", 10))
     VECTOR_STORE_MAX_SIZE: int | None = _get_vector_store_max_size()
     VECTOR_STORE_PATH: str = os.getenv("VECTOR_STORE_PATH", "vector_store.json")
 


### PR DESCRIPTION
## Summary
- add `DAILY_MSG_LIMIT` setting
- allow `RateLimitMiddleware` bypass and period control
- enforce daily limit in main and add tests

## Testing
- `ruff check utils/config.py utils/rate_limiter.py main.py tests/test_rate_limiter.py`
- `pytest tests/test_rate_limiter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4d49e8958832988c447c187c9df27