### PR TITLE
Collect contributor chat IDs from environment

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from utils.config import settings
 from utils import dayandnight
 from utils import knowtheworld
 from utils.genesis1 import run_genesis1
-from utils.genesis2 import genesis2_sonar_filter
+from utils.genesis2 import genesis2_sonar_filter, assemble_final_reply  # noqa: F401
 from utils.genesis3 import genesis3_deep_dive
 from utils.genesis6 import genesis6_profile_filter
 from utils.deepdiving import perplexity_search
@@ -62,10 +62,7 @@ CREATOR_CHAT = settings.CREATOR_CHAT
 PINECONE_API_KEY = settings.PINECONE_API_KEY
 PINECONE_INDEX = settings.PINECONE_INDEX
 PINECONE_ENV = settings.PINECONE_ENV
-
-CONTRIBUTOR_CHAT_IDS: set[str] = {
-    cid for cid in os.getenv("CONTRIBUTOR_CHAT_IDS", "").split(",") if cid
-}
+CONTRIBUTOR_CHAT_IDS: set[str] = set(settings.CONTRIBUTOR_CHAT_IDS)
 
 # Для webhook
 BASE_WEBHOOK_URL = settings.BASE_WEBHOOK_URL  # URL вашего приложения (для Railway)

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -15,3 +15,12 @@ def test_missing_openai_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
         importlib.reload(config)
+
+
+def test_contributor_chat_ids(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("CONTRIBUTOR_CHAT01", "100")
+    monkeypatch.setenv("CONTRIBUTOR_CHAT02", "200")
+    importlib.reload(config)
+    assert config.settings.CONTRIBUTOR_CHAT_IDS == ["100", "200"]

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
+import re
 
 def _get_vector_store_max_size() -> int | None:
     value = os.getenv("VECTOR_STORE_MAX_SIZE")
@@ -25,6 +26,7 @@ class Settings:
     AGENT_GROUP: str = os.getenv("AGENT_GROUP_ID", "-1001234567890")
     GROUP_CHAT: str = os.getenv("GROUP_CHAT", "")
     CREATOR_CHAT: str = os.getenv("CREATOR_CHAT", "")
+    CONTRIBUTOR_CHAT_IDS: list[str] = field(default_factory=list)
     PPLX_API_KEY: str = os.getenv("PPLX_API_KEY", os.getenv("PERPLEXITY_API_KEY", ""))
     RATE_LIMIT_COUNT: int = int(os.getenv("RATE_LIMIT_COUNT", 20))
     RATE_LIMIT_PERIOD: float = float(os.getenv("RATE_LIMIT_PERIOD", 60))
@@ -44,5 +46,12 @@ class Settings:
                 "Missing required environment variables: " + ", ".join(missing)
             )
 
+# Collect contributor chat IDs before instantiating settings
+_contrib_pattern = re.compile(r"^CONTRIBUTOR_CHAT\d+$")
+_contrib_ids = [
+    os.environ[key]
+    for key in sorted(os.environ)
+    if _contrib_pattern.match(key) and os.environ[key]
+]
 
-settings = Settings()
+settings = Settings(CONTRIBUTOR_CHAT_IDS=_contrib_ids)


### PR DESCRIPTION
## Summary
- gather CONTRIBUTOR_CHATxx environment values and expose them in Settings.CONTRIBUTOR_CHAT_IDS
- include contributor chat IDs alongside creator chat in RateLimitMiddleware bypass
- test config for reading contributor chat environment variables

## Testing
- `flake8 utils/config.py main.py tests/test_config_env.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d79b660c8329b92a3cc13d3f3821