### PR TITLE
Add detailed rate limit logging and test

### DIFF
--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -45,7 +45,10 @@ async def test_rate_limiter_logs_exceed(caplog):
         await middleware(handler, message, {})
         await middleware(handler, message, {})
 
-    assert any("Rate limit exceeded" in r.message for r in caplog.records)
+    assert any(
+        r.message == "Rate limit exceeded: user=1, limit=1/60s"
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -16,7 +16,7 @@ def setup_logging() -> None:
         LOG_FILE, when="W0", backupCount=8, encoding="utf-8"
     )
     formatter = logging.Formatter(
-        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
     )
     handler.setFormatter(formatter)
 

--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -49,7 +49,12 @@ class RateLimitMiddleware(BaseMiddleware):
                 timestamps.popleft()
 
             if len(timestamps) >= self.limit:
-                self.logger.warning("Rate limit exceeded for user %s", user_id)
+                self.logger.warning(
+                    "Rate limit exceeded: user=%s, limit=%d/%ds",
+                    user_id,
+                    self.limit,
+                    self.window,
+                )
                 if self.delay > 0:
                     await asyncio.sleep(self.delay)
                     return await handler(event, data)


### PR DESCRIPTION
## Summary
- log user, limit and window when rate limit exceeded
- include timestamp and level in logging format
- test warning emitted on rate limit exceed using caplog

## Testing
- `flake8 utils/rate_limiter.py utils/logging_config.py tests/test_rate_limiter.py`
- `pytest tests/test_rate_limiter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4da19dcc4832984b7dcb03bb43a4c